### PR TITLE
fix issue 352 llexec goes into infinite loop whn stdin is a pipe

### DIFF
--- a/src/interp/progerr.c
+++ b/src/interp/progerr.c
@@ -131,8 +131,10 @@ prog_var_error_zstr (PNODE node, SYMTAB stab, PNODE arg, PVALUE val, ZSTR zstr)
 
 	if (dbg_mode != -99 && dbg_mode != 3) {
 		INT ch = 0;
-		while (!(ch=='d' || ch=='q'))
+		while (!(ch=='d' || ch=='q')) {
 			ch = rptui_prompt_stdout(_("Enter d for debugger, q to quit"));
+                        if (ch == 0) ch = 'q'; 
+                }
 		if (ch == 'q')
 			dbg_mode = -99;
 	}


### PR DESCRIPTION
and a run time error occurs in the script being executed.