### PR TITLE
Split version and tag handling, move tag from configure.ac to version.h

### DIFF
--- a/build/setversions.sh
+++ b/build/setversions.sh
@@ -162,7 +162,7 @@ function applyversion {
   SEDPAT="s/\(AC_INIT(lifelines,[ ]*\)[0-9][[:alnum:].\-]*)$/\1$VERSION)/"
   alterfile $ROOTDIR/configure.ac "$SEDPAT"
 
-  SEDPAT="s/\(#define lifelines_version [ ]*\)[0-9][[:alnum:].\-]*$/\1$VERSION/"
+  SEDPAT="s/\(%define lifelines_version [ ]*\)[0-9][[:alnum:].\-]*$/\1$VERSION/"
   alterfile $ROOTDIR/build/rpm/lifelines.spec "$SEDPAT"
 
   SEDPAT="s/\(release version=\)\"[0-9][[:alnum:].\-]*\"/\1\"$VERSION\"/"

--- a/src/hdrs/version.h
+++ b/src/hdrs/version.h
@@ -5,7 +5,7 @@
 #define LIFELINES_VERSION PACKAGE_VERSION
 
 /* This is the private build version, appended to the public version */
-#define LIFELINES_VERSION_EXTRA "(official)"
+#define LIFELINES_VERSION_EXTRA "(alpha)"
 
 /* Function prototypes */
 STRING get_lifelines_version (INT maxlen);


### PR DESCRIPTION
@stevedum pointed out that the tag goes in version.h and becomes part of program banners, so move it from configure.ac to version.h.   This also better aligns with GNU standards.