### PR TITLE
Fix a few issues reported by sonarqube

### DIFF
--- a/src/btree/index.c
+++ b/src/btree/index.c
@@ -53,6 +53,7 @@ crtindex (BTREE btree)
 	if (fwrite(&bkfile(btree), sizeof(bkfile(btree)), 1, bkfp(btree)) != 1) {
 		char scratch[200];
 		snprintf(scratch, sizeof(scratch), "Error updating keyfile for new index");
+		fclose(bkfp(btree));
 		FATAL2(scratch);
 	}
 	writeindex(btree, index);
@@ -99,6 +100,7 @@ readindex (BTREE btr, FKEY ikey, BOOLEAN robust)
 			goto readindex_end;
 		}
 		snprintf(scratch, sizeof(scratch), "Undersized (<%d) index file: %s", BUFLEN, fkey2path(ikey));
+		fclose(fi);
 		FATAL2(scratch);
 	}
 readindex_end:
@@ -122,9 +124,10 @@ writeindex (BTREE btr, INDEX index)
 	}
 	if (fwrite(index, BUFLEN, 1, fi) != 1) {
 		snprintf(scratch, sizeof(scratch), "Error writing index file: %s", fkey2path(ixself(index)));
+		fclose(fi);
 		FATAL2(scratch);
 	}
-	if (fclose(fi) != 0) FATAL2(scratch);
+	fclose(fi);
 }
 /*==============================================
  * initcache -- Initialize index cache for btree

--- a/src/gedlib/gstrings.c
+++ b/src/gedlib/gstrings.c
@@ -160,12 +160,10 @@ indi_to_list_string (NODE indi, NODE fam, INT len, RFMT rfmt, BOOLEAN appkey)
 	    else hasfamily = 0;
 	    if(hasfamily || hasparents) {
 		ASSERT(linelen > 5);
-		*p++ = ' '; linelen--;
-		*p++ = '['; linelen--;
-		if(hasparents) { *p++ = 'P'; linelen--; }
-		if(hasfamily) { *p++ = 'S'; linelen--; }
-		*p++ = ']'; linelen--;
-		*p = '\0';
+		char *value = (hasparents ? (hasfamily ? "PS" : "P")
+                                          : (hasfamily ? "S"  : "" ));
+		snprintf(p, linelen, " [%s]", value);
+		linelen -= (3 + strlen (value));
 		ASSERT(linelen > 0);
 	    }
 	}

--- a/src/gedlib/gstrings.c
+++ b/src/gedlib/gstrings.c
@@ -160,8 +160,9 @@ indi_to_list_string (NODE indi, NODE fam, INT len, RFMT rfmt, BOOLEAN appkey)
 	    else hasfamily = 0;
 	    if(hasfamily || hasparents) {
 		ASSERT(linelen > 5);
-		char *value = (hasparents ? (hasfamily ? "PS" : "P")
-                                          : (hasfamily ? "S"  : "" ));
+		char *with_p_fam    = (hasfamily ? "PS" : "P");
+		char *without_p_fam = (hasfamily ? "S"  : "" );
+		char *value = (hasparents ? with_p_fam : without_p_fam);
 		snprintf(p, linelen, " [%s]", value);
 		linelen -= (3 + strlen (value));
 		ASSERT(linelen > 0);

--- a/src/interp/interp.c
+++ b/src/interp/interp.c
@@ -601,11 +601,9 @@ interpret (PNODE node, SYMTAB stab, PVALUE *pval)
 		case IICONS:
 			prog_error(node, _("integer constant not allowed here.  Use d(constant) instead.\n"));
 			goto interp_fail;
-			break;
 		case IFCONS:
 			prog_error(node, _("floating-point constant not allowed here.  Use f(constant) instead.\n"));
 			goto interp_fail;
-			break;
 		case ISCONS:
 			poutput(pvalue_to_string(node->vars.iscons.value), &eflg);
 			if (eflg)

--- a/src/liflines/miscutls.c
+++ b/src/liflines/miscutls.c
@@ -148,8 +148,6 @@ sighand_cursesui(int sig)
 void
 sighand_cmdline(int sig)
 {
-	sig = sig;	/* UNUSED */
-
 	closebtree(BTR);
         exit(1);
 }

--- a/src/tools/misc.c
+++ b/src/tools/misc.c
@@ -36,8 +36,6 @@ extern BTREE BTR;
 void
 sighand_cmdline (int sig)
 {
-	sig = sig;	/* UNUSED */
-
 	closebtree(BTR);
         exit(1);
 }


### PR DESCRIPTION
btree/index.c - files not closed.  (They will closed implicity via FATAL2 / __fatal / exit but ...)
gedlib/gstrings.c - fix a claimed buffer overrun.  (Not a bug, but rewrite code to be cleaner, sorta.)
interp/interp.c - remove break after goto (unreachable)
liflines/miscutls.c - remove self-assignment
tools/misc.c - remove self-assingment
