### PR TITLE
Fix memory leaks in select_database, UI window list and interp

### DIFF
--- a/src/hdrs/liflines.h
+++ b/src/hdrs/liflines.h
@@ -76,7 +76,7 @@ void view_array(STRING ttl, INT no, STRING *pstrngs);
 
 /* selectdb.c */
 BOOLEAN open_or_create_database(INT alteration, STRING *dbused);
-BOOLEAN select_database(STRING dbrequested, INT alteration, STRING * perrmsg);
+BOOLEAN select_database(STRING * dbrequested, INT alteration, STRING * perrmsg);
 
 /* miscutls.c */
 void sighand_cursesui(int sig);

--- a/src/interp/yacc.y
+++ b/src/interp/yacc.y
@@ -129,12 +129,14 @@ rspec	:	defn
 defn 	:	proc
 	|	func
 	|	IDEN '(' IDEN ')' {
+			/* consumes $1 and $3 */
 			if (eqstr("global", (STRING) $1))
 				pa_handle_global((STRING) $3);
-				free_iden($1);
-				free_iden($3);
+			free_iden($1);
+			free_iden($3);
 		}
 	|	IDEN '(' SCONS ')' {
+			/* consumes $1 */
 			if (eqstr("include", (STRING) $1))
 				pa_handle_include(pactx, (PNODE) $3);
 			if (eqstr("option", (STRING) $1))
@@ -150,12 +152,14 @@ defn 	:	proc
 proc	:	PROC IDEN '(' idenso ')' '{' tmplts '}' {
 			/* consumes $2 */
 			pa_handle_proc(pactx, (STRING) $2, (PNODE) $4, (PNODE) $7);
+			free_iden($2);
 		}
 
 	;
 func	:	FUNC_TOK IDEN '(' idenso ')' '{' tmplts '}' {
 			/* consumes $2 */
 			pa_handle_func(pactx, (STRING) $2, (PNODE) $4, (PNODE) $7);
+			free_iden($2);
 		}
 	;
 idenso	:	/* empty */ {
@@ -168,11 +172,13 @@ idenso	:	/* empty */ {
 idens	:	IDEN {
 			/* consumes $1 */
 			$$ = create_iden_node(pactx, (STRING)$1);
+			free_iden($1);
 		}
 	|	IDEN ',' idens {
 			/* consumes $1 */
 			$$ = create_iden_node(pactx, (STRING)$1);
 			inext(((PNODE)$$)) = (PNODE) $3;
+			free_iden($1);
 		}
 	;
 tmplts	:	tmplt {
@@ -188,100 +194,137 @@ tmplt	:	CHILDREN m '(' expr ',' IDEN ',' IDEN ')' '{' tmplts '}'
 			/* consumes $6 and $8 */
 			$$ = children_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (PNODE)$11);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
 		}
 	|	SPOUSES m '(' expr ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 */
 			$$ = familyspouses_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (PNODE)$11);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
 		}
 	|	SPOUSES m '(' expr ',' IDEN ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 and $10 */
 			$$ = spouses_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (STRING)$10, (PNODE)$13);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
+			free_iden($10);
 		}
 	|	FAMILIES m '(' expr ',' IDEN ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 and $10 */
 			$$ = families_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (STRING)$10, (PNODE)$13);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
+			free_iden($10);
 		}
 	|	FATHERS m '(' expr ',' IDEN ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 and $10 */
 			$$ = fathers_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (STRING)$10, (PNODE)$13);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
+			free_iden($10);
 		}
 	|	MOTHERS m '(' expr ',' IDEN ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 and $10 */
 			$$ = mothers_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (STRING)$10, (PNODE)$13);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
+			free_iden($10);
 		}
 	|	PARENTS m '(' expr ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 */
 			$$ = parents_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (PNODE)$11);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
 		}
 	|	FORINDISET m '(' expr ',' IDEN ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 and $10 */
 			$$ = forindiset_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (STRING)$10, (PNODE)$13);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
+			free_iden($10);
 		}
 	|	FORLIST_TOK m '(' expr ',' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 and $8 */
 			$$ = forlist_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (PNODE)$11);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
 		}
 	|	FORINDI m '(' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $4 and $6 */
 			$$ = forindi_node(pactx, (STRING)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($4);
+			free_iden($6);
 		}
 	|	FORNOTES m '(' expr ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $6 */
 			$$ = fornotes_node(pactx, (PNODE)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
 		}
 	|	FORFAM m '(' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $4 and $6 */
 			$$ = forfam_node(pactx, (STRING)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($4);
+			free_iden($6);
 		}
 	|	FORSOUR m '(' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $4 and $6 */
 			$$ = forsour_node(pactx, (STRING)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($4);
+			free_iden($6);
 		}
 	|	FOREVEN m '(' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $4 and $6 */
 			$$ = foreven_node(pactx, (STRING)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($4);
+			free_iden($6);
 		}
 	|	FOROTHR m '(' IDEN ',' IDEN ')' '{' tmplts '}'
 		{
 			/* consumes $4 and $6 */
 			$$ = forothr_node(pactx, (STRING)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($4);
+			free_iden($6);
 		}
 	|	TRAVERSE m '(' expr ',' IDEN ',' IDEN ')' '{' tmplts '}' {
-			/* consumes $6 */
+			/* consumes $6 and $8 */
 			$$ = traverse_node(pactx, (PNODE)$4, (STRING)$6, (STRING)$8, (PNODE)$11);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
+			free_iden($8);
 		}
 	|	FORNODES m '(' expr ',' IDEN ')' '{' tmplts '}' {
 			/* consumes $6 */
 			$$ = fornodes_node(pactx, (PNODE)$4, (STRING)$6, (PNODE)$9);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($6);
 		}
 	|	IF m '(' expr secondo ')' '{' tmplts '}' elsifso elseo {
 			inext(((PNODE)$4)) = (PNODE)$5;
@@ -308,6 +351,7 @@ tmplt	:	CHILDREN m '(' expr ',' IDEN ',' IDEN ')' '{' tmplts '}'
 			/* consumes $2 */
 			$$ = create_call_node(pactx, (STRING)$2, (PNODE)$5);
 			((PNODE)$$)->i_line = (INTPTR)$3;
+			free_iden($2);
 		}
 	|	BREAK m '(' ')' {
 			$$ = break_node(pactx);
@@ -355,11 +399,13 @@ elseo	:	/* empty */ {
 expr	:	IDEN {
 			/* consumes $1 */
 			$$ = create_iden_node(pactx, (STRING)$1);
+			free_iden($1);
 		}
 	|	IDEN m '(' exprso ')' {
 			/* consumes $1 */
 			$$ = func_node(pactx, (STRING)$1, (PNODE)$4);
 			((PNODE)$$)->i_line = (INTPTR)$2;
+			free_iden($1);
 		}
 	|	SCONS {
 			$$ = $1;

--- a/src/liflines/llexec.c
+++ b/src/liflines/llexec.c
@@ -335,7 +335,7 @@ prompt_for_db:
 		} else {
 			strupdate(&dbrequested, "");
 		}
-		if (!select_database(dbrequested, alteration, &errmsg)) {
+		if (!select_database(&dbrequested, alteration, &errmsg)) {
 			if (errmsg) {
 				llwprintf("%s", errmsg);
 			}

--- a/src/liflines/main.c
+++ b/src/liflines/main.c
@@ -377,10 +377,8 @@ prompt_for_db:
 		STRING errmsg=0;
 		if (!alldone && c>0) {
 			dbrequested = strsave(argv[optind]);
-		} else {
-			strupdate(&dbrequested, "");
 		}
-		if (!select_database(dbrequested, alteration, &errmsg)) {
+		if (!select_database(&dbrequested, alteration, &errmsg)) {
 			if (errmsg) {
 				llwprintf("%s", errmsg);
 			}

--- a/src/liflines/selectdb.c
+++ b/src/liflines/selectdb.c
@@ -81,7 +81,6 @@ select_database (STRING * dbrequested, INT alteration, STRING * perrmsg)
 		/* ask_for_db_filename returns static buffer, we save it below */
 		if (!ask_for_db_filename(_(qSidldir), _(qSidldrp), dbdir, dbname, sizeof(dbname))
 			|| !dbname[0]) {
-			dbrequested = NULL;	// leak!
 			*perrmsg = _(qSiddbse);
 			return FALSE;
 		}

--- a/src/stdlib/list.c
+++ b/src/stdlib/list.c
@@ -596,16 +596,10 @@ delete_list_element (LIST list, INT index1b, ELEMENT_DESTRUCTOR func)
 	node = nth_in_list_from_tail(list, index1b, createels, 0);
 	if (!node) return FALSE;
 	if (llocks(node)) return FALSE;
-	if (llen(list) == 1) {
-		/* removing last element of list */
-		llen(list) = 0;
-		lhead(list) = ltail(list) = 0;
-		if (func)
-			(*func)(lelement(node));
-		stdfree(node);
-		return TRUE;
-	}
 	detach_node_from_list(list, node);
+	if (func)
+		(*func)(lelement(node));
+	stdfree(node);
 	return TRUE;
 }
 #endif
@@ -658,9 +652,11 @@ find_delete_list_elements (LIST list, VPTR param,
 			if (ltype(list) == LISTDOFREE) {
 				free_list_element(lelement(lnode));
 			}
+			stdfree(lnode);
 			if (!deleteall)
 				return count;
 		}
+		stdfree(lnode);
 		lnode = lnext;
 	}
 	return count;


### PR DESCRIPTION
See #379 for description is memory leaks.

Fixes:
1) Change select_database to take a STRING*, not STRING, for the dbrequested argument.  This allows any changed allocations to flow back to the caller where they can be freed up.
2) Eliminate the code that assigns an empty string to dbrequested.

src/liflines/llexec.c
src/liflines/main.c
src/liflines/selectdb.c

3) This is fixed by deleting the list node after (optionally) freeing the list element in find_delete_list_elements().

src/stdlib/list.c

4) This is fixed by calling free_iden() for each IDEN in yacc.y

src/interp/yacc.y