### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/reports/gen_index
+++ b/reports/gen_index
@@ -5,6 +5,7 @@
 # January 2003 
 
 use strict;
+use POSIX qw(strftime);
 
 my $debug = 0;		#non-zero to enable debug output
 my $viewoutput = 0;	#non-zero to enable printing output information
@@ -93,7 +94,7 @@ have text identifying the person who generated the report.
 EOF
 }
 sub print_trailer {
-    my $today = `date "+%d %b %Y"`;
+    my $today = strftime("%Y-%m-%d", gmtime($ENV{SOURCE_DATE_EPOCH} || time));
     print OUT  <<EOF
 </DL>
 <center>


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also switch to UTC to be independent of timezone.
Also use ISO 8601 date format to be easier to parse.
This also avoids use of `%b` that can vary from locales.

This PR was done while working on reproducible builds for openSUSE.