### PR TITLE
Fix type of listbadkeys

### DIFF
--- a/src/gedlib/keytonod.c
+++ b/src/gedlib/keytonod.c
@@ -44,9 +44,7 @@
  *********************************************/
 
 char badkeylist[100] = "";
-int listbadkeys = 0;
-
-
+INT listbadkeys = 0;
 
 /*===============================
  * CACHEEL -- Cache element type.

--- a/src/liflines/ask.c
+++ b/src/liflines/ask.c
@@ -449,7 +449,7 @@ choose_from_indiseq (INDISEQ seq, ASK1Q ask1, STRING titl1, STRING titln)
 
 	i = choose_one_from_indiseq_if_needed(seq, ask1, titl1, titln);
 	if (i == -1) return NULL;
-	listbadkeys=1;
+	listbadkeys = 1;
 	/* which typed value indiseq is this ? */
 	if (!indiseq_is_valtype_ival(seq) && !indiseq_is_valtype_null(seq))
 	{


### PR DESCRIPTION
This is a definite but, which may have different impact on different platforms.

(This type difference apparently causes an infinite loop on MacOSX as we go through the cleanup code and repeatedly segfault.  I could not confirm on Ubuntu.)