### PR TITLE
Remove memory leak in btree processing.

### DIFF
--- a/src/btree/opnbtree.c
+++ b/src/btree/opnbtree.c
@@ -287,7 +287,7 @@ immutretry:
 
 	if (!(bmaster(btree)))
 	{
-                stdfree(bbasedir(btree));
+		stdfree(bbasedir(btree));
 		stdfree(btree);
 		*lldberr = BTERR_MASTER_INDEX;
 		goto failopenbtree;
@@ -462,8 +462,8 @@ exit_closebtree:
 		freecache(btree);
 		if(bmaster(btree)) {
 			stdfree(bmaster(btree));
-                }
-                stdfree(bbasedir(btree));
+		}
+		stdfree(bbasedir(btree));
 		stdfree(btree);
 	}
 	return result;

--- a/src/btree/opnbtree.c
+++ b/src/btree/opnbtree.c
@@ -282,11 +282,12 @@ immutretry:
 
 /* Create BTREE structure */
 	btree = (BTREE) stdalloc(sizeof *btree);
-	bbasedir(btree) = dir;
+	bbasedir(btree) = strsave(dir);
 	bmaster(btree) = readindex(btree, kfile1.k_mkey, TRUE);
 
 	if (!(bmaster(btree)))
 	{
+                stdfree(bbasedir(btree));
 		stdfree(btree);
 		*lldberr = BTERR_MASTER_INDEX;
 		goto failopenbtree;
@@ -461,7 +462,8 @@ exit_closebtree:
 		freecache(btree);
 		if(bmaster(btree)) {
 			stdfree(bmaster(btree));
-		}
+                }
+                stdfree(bbasedir(btree));
 		stdfree(btree);
 	}
 	return result;

--- a/src/liflines/llexec.c
+++ b/src/liflines/llexec.c
@@ -106,7 +106,6 @@ main (int argc, char **argv)
 	int c;
 	BOOLEAN ok=FALSE;
 	STRING dbrequested=NULL; /* database (path) requested */
-	STRING dbused=NULL; /* database (path) found */
 	BOOLEAN forceopen=FALSE, lockchange=FALSE;
 	char lockarg = 0; /* option passed for database lock */
 	INT alteration=0;
@@ -372,7 +371,6 @@ finish:
 	/* we free this not because we care so much about these tiny amounts
 	of memory, but to ensure we have the memory management right */
 	/* strfree frees memory & nulls pointer */
-	strfree(&dbused);
 	strfree(&dbrequested);
 	strfree(&readpath_file);
 	shutdown_interpreter();

--- a/src/liflines/main.c
+++ b/src/liflines/main.c
@@ -387,6 +387,7 @@ prompt_for_db:
 			goto finish;
 		}
 	}
+	strfree(&dbrequested);
 
 	/* Start Program */
 	if (!init_lifelines_postdb()) {
@@ -425,7 +426,6 @@ finish:
 	of memory, but to ensure we have the memory management right */
 	/* strfree frees memory & nulls pointer */
 	strfree(&dbused);
-	strfree(&dbrequested);
 	strfree(&readpath_file);
 	shutdown_interpreter();
 	close_lifelines();

--- a/src/liflines/selectdb.c
+++ b/src/liflines/selectdb.c
@@ -122,8 +122,7 @@ select_database (STRING * dbrequested, INT alteration, STRING * perrmsg)
 		return FALSE;
 	}
 
-	// NOTE: While dbused is a local, a pointer to it is saved in
-	// open_or_create_database() so don't free it here!
+        stdfree(dbused);
 	return TRUE;
 }
 /*==================================================

--- a/src/liflines/selectdb.c
+++ b/src/liflines/selectdb.c
@@ -122,7 +122,7 @@ select_database (STRING * dbrequested, INT alteration, STRING * perrmsg)
 		return FALSE;
 	}
 
-        stdfree(dbused);
+	stdfree(dbused);
 	return TRUE;
 }
 /*==================================================

--- a/src/tools/lldump.c
+++ b/src/tools/lldump.c
@@ -218,11 +218,11 @@ void dump_index(STRING dir)
 {
 	INDEX index;
 	FKEY mkey = path2fkey("aa/aa");
-        
+ 
 	if (strcmp(dir, bbasedir(BTR)) != 0) {
-            printf("Error, mismatch in btree file names, %s and %s\n",
-                   dir, bbasedir(BTR));
-        }
+		printf("Error, mismatch in btree file names, %s and %s\n",
+			dir, bbasedir(BTR));
+	}
 	index = readindex(BTR, mkey, TRUE);
 
 	traverse_index_blocks(BTR, index, NULL, tf_print_index, NULL);
@@ -259,7 +259,7 @@ void print_index(INDEX index, INT32 *offset)
 	*offset += sizeof(index->ix_self);
 
 	printf(FMT_INT32_HEX ": ix_type: " FMT_INT32 " (%s)\n", *offset, index->ix_type,
-               (index->ix_type == 1 ? "INDEX" : (index->ix_type == 2 ? "BLOCK" : "UNKNOWN")));
+	    (index->ix_type == 1 ? "INDEX" : (index->ix_type == 2 ? "BLOCK" : "UNKNOWN")));
 	*offset += sizeof(index->ix_type);
 
 #if __WORDSIZE != 16
@@ -298,11 +298,11 @@ void dump_block(STRING dir)
 {
 	INDEX index;
 	FKEY mkey = path2fkey("aa/aa");
-        
+
 	if (strcmp(dir, bbasedir(BTR)) != 0) {
-            printf("Error, mismatch in btree file names, %s and %s\n",
-                   dir, bbasedir(BTR));
-        }
+		printf("Error, mismatch in btree file names, %s and %s\n",
+		    dir, bbasedir(BTR));
+	}
 	index = readindex(BTR, mkey, TRUE);
 
 	traverse_index_blocks(BTR, index, NULL, NULL, tf_print_block);
@@ -497,9 +497,9 @@ void print_keyfile(KEYFILE1* kfile1, KEYFILE2* kfile2, INT32 size)
 void dump_xref(STRING dir)
 {
 	if (strcmp(dir, bbasedir(BTR)) != 0) {
-            printf("Error, mismatch in btree file names, %s and %s\n",
-                   dir, bbasedir(BTR));
-        }
+		printf("Error, mismatch in btree file names, %s and %s\n",
+			dir, bbasedir(BTR));
+	}
 
 	if (!openxref(FALSE))
 	{

--- a/src/tools/lldump.c
+++ b/src/tools/lldump.c
@@ -219,7 +219,10 @@ void dump_index(STRING dir)
 	INDEX index;
 	FKEY mkey = path2fkey("aa/aa");
         
-	bbasedir(BTR) = dir;
+	if (strcmp(dir, bbasedir(BTR)) != 0) {
+            printf("Error, mismatch in btree file names, %s and %s\n",
+                   dir, bbasedir(BTR));
+        }
 	index = readindex(BTR, mkey, TRUE);
 
 	traverse_index_blocks(BTR, index, NULL, tf_print_index, NULL);
@@ -296,7 +299,10 @@ void dump_block(STRING dir)
 	INDEX index;
 	FKEY mkey = path2fkey("aa/aa");
         
-	bbasedir(BTR) = dir;
+	if (strcmp(dir, bbasedir(BTR)) != 0) {
+            printf("Error, mismatch in btree file names, %s and %s\n",
+                   dir, bbasedir(BTR));
+        }
 	index = readindex(BTR, mkey, TRUE);
 
 	traverse_index_blocks(BTR, index, NULL, NULL, tf_print_block);
@@ -490,7 +496,10 @@ void print_keyfile(KEYFILE1* kfile1, KEYFILE2* kfile2, INT32 size)
  *=============================*/
 void dump_xref(STRING dir)
 {
-	dir = dir;	/* UNUSED */
+	if (strcmp(dir, bbasedir(BTR)) != 0) {
+            printf("Error, mismatch in btree file names, %s and %s\n",
+                   dir, bbasedir(BTR));
+        }
 
 	if (!openxref(FALSE))
 	{


### PR DESCRIPTION
Transfer ownership of btree b_basedir to btree by saving a copy of
the basedir i.e bbasedir(btree) = strsave(dir).
This assigns clear ownership of b_basedir to creation and destruction of
a btree.  Also makes it easier for routines to manage dbused and dbrequested.