### PR TITLE
Fix valgrind errors on Royal92 database open due to invalid memory accesses

### DIFF
--- a/src/liflines/browse.c
+++ b/src/liflines/browse.c
@@ -1573,7 +1573,7 @@ load_nkey_list (STRING key, struct hist * histp)
 		return;
 	ptr = (INT32 *)rawrec;
 	temp = *ptr++;
-	if (temp<1 || temp > 9999) {
+	if (temp<0 || temp > 9999) {
 		/* #records failed sanity check */
 		msg_error("%s", _(qSbadhistcnt));
 		goto end;

--- a/src/liflines/browse.c
+++ b/src/liflines/browse.c
@@ -1561,15 +1561,17 @@ static void
 load_nkey_list (STRING key, struct hist * histp)
 {
 	STRING rawrec;
-	INT * ptr;
-	INT count, len, i, temp;
+	INT32 * ptr;
+	INT32 count;
+	INT32 temp;
+	INT len, i;
 
 	count = 0;
 	if (!(rawrec = retrieve_raw_record(key, &len)))
 		return;
 	if (len < 8 || (len % 8) != 0)
 		return;
-	ptr = (INT *)rawrec;
+	ptr = (INT32 *)rawrec;
 	temp = *ptr++;
 	if (temp<1 || temp > 9999) {
 		/* #records failed sanity check */
@@ -1635,7 +1637,9 @@ static void
 save_nkey_list (STRING key, struct hist * histp)
 {
 	FILE * fp=0;
-	INT next, count, temp;
+	INT i, next;
+	INT32 count;	// write buffer for histp->count value
+	INT32 temp;	// write buffer for histp->list[] values
 	size_t rtn;
 
 	count = get_hist_count(histp);
@@ -1649,9 +1653,12 @@ save_nkey_list (STRING key, struct hist * histp)
 	rtn = fwrite(&count, 4, 1, fp); ASSERT(rtn==1);
 	rtn = fwrite(&count, 4, 1, fp); ASSERT(rtn==1);
 
+	/* write entries */
 	next = histp->start;
-	while (1) {
+	for (i=0; i<count; ++i)
+	{
 		/* write type & number, 4 bytes each */
+		/* type = char, keynum = INT (truncated!) */
 		temp = histp->list[next].ntype;
 		rtn = fwrite(&temp, 4, 1, fp); ASSERT(rtn==1);
 		temp = histp->list[next].keynum;
@@ -2031,7 +2038,7 @@ get_vhist_len (void)
 	return get_hist_count(&vhist);
 }
 /*==================================================
- * get_vhist_len -- how many records currently in change history list ?
+ * get_chist_len -- how many records currently in change history list ?
  * Created: 2002/06/23, Perry Rapp
  *================================================*/
 INT

--- a/src/tools/lldump.c
+++ b/src/tools/lldump.c
@@ -760,7 +760,7 @@ void print_block(BTREE btree, BLOCK block, INT32 *offset)
 				printf("    " FMT_INT_3 ". %-*s %s %s%s\n" ,
 					m+1, keylen, akey.rkeyfirst,
 					(first == 'N' ? " name " :
-				  	" identified by 'REFN "), &rec[stroff],
+					" identified by 'REFN "), &rec[stroff],
 					(first == 'N' ? "" : "'"));
 				lennames += strlen(&rec[stroff])+1;
 				col1 += sizeof(RKEY);
@@ -776,7 +776,7 @@ void print_block(BTREE btree, BLOCK block, INT32 *offset)
 			//
 			// See save_nkey_list and load_nkey_list
 			//
-			INT32 *ptr = &rec[0];
+			INT32 *ptr = (INT32 *)&rec[0];
 			INT32 count1 = *ptr++;
 			INT32 count2 = *ptr++;
 			INT32 count = ((count1>count2) ? count2 : count1);
@@ -786,7 +786,7 @@ void print_block(BTREE btree, BLOCK block, INT32 *offset)
 			printf("   " FMT_INT32_HEX ": count1 " FMT_INT32 "\n",
 				*offset,count1);
 			printf("   " FMT_INT32_HEX ": count1 " FMT_INT32 "\n",
-				*offset+sizeof(INT32),count2);
+				*offset+(INT32)sizeof(INT32),count2);
 
 			// print out entries
 			for (i=0; i<count; i++)
@@ -801,7 +801,7 @@ void print_block(BTREE btree, BLOCK block, INT32 *offset)
 					   *offset + offset2, (INT)num);
 			}
 		} else {
-			// handle all but N,R - E F I P S V X 
+			// handle all but N,R,H - E F I P S V X
 			// these have just text data
 			if (rec != NULL)
 				printf(FMT_INT32_HEX "-" FMT_INT32_HEX 


### PR DESCRIPTION
Fix #423 reported by Michael Hendry.

The 4 errors reported by valgrind are due to a bug in save_nkey_list().

The save_nkey_list() routine does not use the size of the list when writing to disk, but instead uses the circular buffer head/tail values (start and past_end). For an empty (uninitialized) list, start=-1 and past_end=0. This causes the routine to attempt to write the first (-1th!) entry to disk.

To resolve this I have adjusted the logic to match that of load_nkey_list(), which uses the count (size) of the list, which in this case will be 0, and will avoid the invalid array index.

I should also point out that most people will not see these errors, as history retention (SaveHistory in .linesrc) is disabled by default. The load/save_nkey_list() routines are used to load and save the view (HISTV) and change (HISTC) history in the database.

Since they are stored in the database, I made the appropriate changes to ensure 64-bit portability, and extended lldump to dump them.