### PR TITLE
Address memory leaks on empty databases

### DIFF
--- a/build/valgrind.sh
+++ b/build/valgrind.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# This script will run LifeLines with valgrind with suitable suppressions.
+# Tested on Ubuntu; changes to this script and the valgrind suppression file
+# will be needed on other platforms.
+
+# Determine root of repository
+if [ ! -f configure.ac ]
+then
+  echo "ERROR: Must be run from the root of the source tree!"
+  exit 1
+else
+  ROOTDIR=`pwd`
+fi
+
+# Check if LifeLines has been built
+if [ ! -f src/liflines/llines ]
+then
+  echo "ERROR: LifeLines has not been built!"
+  exit 1
+fi
+
+valgrind --leak-check=full --show-leak-kinds=all --log-file=valgrind.log --suppressions=build/valgrind.supp.ubuntu src/liflines/llines $@

--- a/build/valgrind.supp.ubuntu
+++ b/build/valgrind.supp.ubuntu
@@ -1,0 +1,59 @@
+# Using valgrind + ncurses will report many leaks.  These are by design.
+# https://invisible-island.net/ncurses/ncurses.faq.html#config_leaks
+{
+   ignore_libncurses_nckeypad_calloc
+   Memcheck:Leak
+   fun:calloc
+   ...
+   obj:/usr/lib/*/libtinfo.so*
+   ...
+   fun:_nc_keypad
+}
+{
+   ignore_libncurses_initscr_malloc
+   Memcheck:Leak
+   fun:malloc
+   ...
+   obj:/usr/lib/*/libncurses*.so*
+   ...
+   fun:initscr
+}
+{
+   ignore_libncurses_initscr_realloc
+   Memcheck:Leak
+   fun:realloc
+   ...
+   obj:/usr/lib/*/libncurses*.so*
+   ...
+   fun:initscr
+}
+{
+   ignore_libncurses_initscr_calloc
+   Memcheck:Leak
+   fun:calloc
+   ...
+   obj:/usr/lib/*/libncurses*.so*
+   ...
+   fun:initscr
+}
+{
+   ignore_libncurses_doupdate_malloc
+   Memcheck:Leak
+   fun:malloc
+   ...
+   fun:doupdate_sp
+}
+{
+   ignore_libncurses_doupdate_realloc
+   Memcheck:Leak
+   fun:realloc
+   ...
+   fun:doupdate_sp
+}
+{
+   ignore_libncurses_doupdate_calloc
+   Memcheck:Leak
+   fun:calloc
+   ...
+   fun:doupdate_sp
+}

--- a/src/gedlib/brwslist.c
+++ b/src/gedlib/brwslist.c
@@ -84,12 +84,20 @@ static LIST browse_lists=0;
  *********************************************/
 
 /*=====================================================
- *  init_browse_lists -- Initialize named browse lists.
+ *  init_browse_lists -- Initialize named browse lists
  *===================================================*/
 void
 init_browse_lists (void)
 {
 	browse_lists = create_list();
+}
+/*=====================================================
+ *  term_browse_lists -- Termiante named browse lists
+ *===================================================*/
+void
+term_browse_lists (void)
+{
+	destroy_list(browse_lists);
 }
 /*===========================================
  *  create_new_blel -- Create browse list entry

--- a/src/gedlib/codesets.c
+++ b/src/gedlib/codesets.c
@@ -194,6 +194,7 @@ term_codesets (void)
 	strfree(&gui_codeset_in);
 	strfree(&report_codeset_out);
 	strfree(&report_codeset_in);
+	strfree(&defcodeset);
 }
 /*=================================================
  * get_defcodeset -- Return user's default codeset

--- a/src/gedlib/gedcomi.h
+++ b/src/gedlib/gedcomi.h
@@ -19,6 +19,7 @@ NODE is_cel_loaded(CACHEEL cel);
 void init_win32_gettext_shim(void);
 void llgettext_init(CNSTRING domain, CNSTRING codeset);
 void update_textdomain_localedir(CNSTRING domain, CNSTRING prefix);
+void llgettext_term(void);
 
 /* names.c */
 RECORD id_by_key(CNSTRING name, char ctype);

--- a/src/gedlib/init.c
+++ b/src/gedlib/init.c
@@ -220,6 +220,7 @@ close_lifelines (void)
 	}
 	term_lloptions();
 	term_date();
+	llgettext_term();
 	term_codesets();
 	strfree(&int_codeset);
 	xlat_shutdown();

--- a/src/gedlib/init.c
+++ b/src/gedlib/init.c
@@ -195,7 +195,6 @@ init_lifelines_postdb (void)
 	if (!openxref(readonly))
 		return FALSE;
 
-
 	transl_load_xlats();
 
 	return TRUE;
@@ -209,6 +208,7 @@ void
 close_lifelines (void)
 {
 	lldb_close(&def_lldb); /* make sure database closed */
+	term_browse_lists();
 	if (editfile) {
 		unlink(editfile);
 		stdfree(editfile);

--- a/src/gedlib/llgettext.c
+++ b/src/gedlib/llgettext.c
@@ -61,6 +61,22 @@ llgettext_init (CNSTRING domain, CNSTRING codeset)
 #endif /* ENABLE_NLS */
 }
 /*==================================================
+ * llgettext_term -- cleans up memory allocation
+ * that may have been performed in llgettext_init
+ *================================================*/
+void
+llgettext_term (void)
+{
+#if ENABLE_NLS
+	if (gt_localeDirs) {
+		destroy_table(gt_localeDirs);
+		gt_localeDirs = 0;
+	}
+	strfree(&gt_codeset);
+#endif
+}
+
+/*==================================================
  * update_textdomain_localedir --
  *  call bindtextdomain with current localedir
  *  domain:  [IN] package domain (eg, "lifelines")

--- a/src/gedlib/llgettext.c
+++ b/src/gedlib/llgettext.c
@@ -74,6 +74,7 @@ llgettext_term (void)
 	}
 	strfree(&gt_codeset);
 #endif
+	strfree(&gt_defLocaleDir);
 }
 
 /*==================================================

--- a/src/hdrs/gedcom.h
+++ b/src/hdrs/gedcom.h
@@ -471,6 +471,7 @@ BOOLEAN store_file_to_db(STRING key, STRING file);
 BOOLEAN store_record(CNSTRING key, STRING rec, INT len);
 RECORD string_to_record(STRING str, CNSTRING key, INT len);
 void termlocale(void);
+void term_browse_lists(void);
 BOOLEAN traverse_nodes(NODE node, BOOLEAN (*func)(NODE, VPTR), VPTR param);
 void traverse_refns(TRAV_REFNS_FUNC func, void *param);
 INT tree_strlen(INT, NODE);

--- a/src/hdrs/menuitem.h
+++ b/src/hdrs/menuitem.h
@@ -70,6 +70,7 @@ typedef struct tag_cmdarray * CMDARRAY;
 struct tag_menuset {
 	CMDARRAY Commands;
 	MenuItem ** items;  /* array of pointers to items */
+	MenuItem ** extraItems;  /* array of pointers to extra items */
 };
 typedef struct tag_menuset *MENUSET;
 

--- a/src/liflines/browse.c
+++ b/src/liflines/browse.c
@@ -106,6 +106,7 @@ static RECORD history_back(struct hist * histp);
 static RECORD do_disp_history_list(struct hist * histp);
 static void history_record(RECORD rec, struct hist * histp);
 static RECORD history_fwd(struct hist * histp);
+static void init_hist_lists(void);
 static void init_hist(struct hist * histp, INT count);
 static void load_hist_lists(void);
 static void load_nkey_list(STRING key, struct hist * histp);
@@ -115,6 +116,8 @@ static void pick_remove_spouse_from_family(RECORD frec);
 static void save_hist_lists(void);
 static void save_nkey_list(STRING key, struct hist * histp);
 static void setrecord(RECORD * dest, RECORD * src);
+static void term_hist_lists(void);
+static void term_hist(struct hist * histp);
 
 /*********************************************
  * local variables
@@ -1505,11 +1508,11 @@ choose_any_other (void)
 	return rec;
 }
 /*==================================================
- * load_hist_lists -- Load previous history from database
- * Created: 2001/12/23, Perry Rapp
+ * init_hist_lists -- initialize history lists
+ * Created: 2021/04/18, Matt Emmerton
  *================================================*/
 static void
-load_hist_lists (void)
+init_hist_lists (void)
 {
 	/* V for visit history, planning to also have a change history */
 	INT count = getlloptint("HistorySize", 20);
@@ -1517,6 +1520,14 @@ load_hist_lists (void)
 		count = 20;
 	init_hist(&vhist, count);
 	init_hist(&chist, count);
+}
+/*==================================================
+ * load_hist_lists -- Load previous history from database
+ * Created: 2001/12/23, Perry Rapp
+ *================================================*/
+static void
+load_hist_lists (void)
+{
 	if (getlloptint("SaveHistory", 0)) {
 		load_nkey_list("HISTV", &vhist);
 		load_nkey_list("HISTC", &chist);
@@ -1535,6 +1546,16 @@ save_hist_lists (void)
 	save_nkey_list("HISTC", &chist);
 }
 /*==================================================
+ * term_hist_lists -- destroy history lists
+ * Created: 2021/04/18, Matt Emmerton
+ *=================================================*/
+static void
+term_hist_lists (void)
+{
+	term_hist(&vhist);
+	term_hist(&chist);
+}
+/*==================================================
  * init_hist -- create & initialize a history list
  * Created: 2001/12/23, Perry Rapp
  *=================================================*/
@@ -1548,6 +1569,16 @@ init_hist (struct hist * histp, INT count)
 	memset(histp->list, 0, size);
 	histp->start = -1;
 	histp->past_end = 0;
+}
+/*==================================================
+ * term_hist -- destroy a history list
+ * Created: 2021/04/18, Matt Emmerton
+ *=================================================*/
+static void
+term_hist (struct hist * histp)
+{
+	stdfree(histp->list);
+	histp->size = 0;
 }
 /*==================================================
  * load_nkey_list -- Load node list from record into NKEY array
@@ -2055,6 +2086,7 @@ get_chist_len (void)
 void
 init_browse_module (void)
 {
+	init_hist_lists();
 	load_hist_lists();
 }
 /*==================================================
@@ -2066,4 +2098,5 @@ void
 term_browse_module (void)
 {
 	save_hist_lists();
+	term_hist_lists();
 }

--- a/src/liflines/main.c
+++ b/src/liflines/main.c
@@ -480,11 +480,9 @@ shutdown_ui (BOOLEAN pause)
 	term_screen();
 	if (pause) /* if error, give user a second to read it */
 		sleep(1);
-	/* TO DO - signals also calls into here -- how do we figure out
-	whether or not we should call endwin ? In case something happened
-	before curses was invoked, or after it already closed ? */
 	/* Terminate Curses UI */
-	endwin();
+	if (!isendwin())
+		endwin();
 }
 /* Finnish language support modifies the soundex codes for names, so
  * a database created with this support is not compatible with other

--- a/src/liflines/menuset.c
+++ b/src/liflines/menuset.c
@@ -84,6 +84,7 @@ menuset_init (MENUSET menuset, STRING title, MenuItem ** MenuItems, MenuItem ** 
 	menuset_clear(menuset);
 	menuset->Commands = cmds;
 	menuset->items = MenuItems;
+	menuset->extraItems = extraItems;
 	for (i=0; MenuItems[i]; ++i)
 		add_menu_item(cmds, MenuItems[i]);
 	for (i=0; extraItems[i]; ++i)
@@ -98,9 +99,18 @@ menuset_init (MENUSET menuset, STRING title, MenuItem ** MenuItems, MenuItem ** 
 void
 menuset_clear (MENUSET menuset)
 {
+	INT i;
 	if (menuset->Commands) {
 		free_cmds(menuset->Commands);
 		menuset->Commands = 0;
+	}
+	if (menuset->items) {
+		for (i=0; menuset->items[i]; ++i)
+			strfree(&menuset->items[i]->LocalizedDisplay);
+	}
+	if (menuset->extraItems) {
+		for (i=0; menuset->extraItems[i]; ++i)
+			strfree(&menuset->extraItems[i]->LocalizedDisplay);
 	}
 }
 /*============================

--- a/src/liflines/screen.c
+++ b/src/liflines/screen.c
@@ -530,11 +530,18 @@ delete_uiwindow (UIWINDOW * uiw)
 {
 	if (*uiw) {
 		UIWINDOW w = *uiw;
+		// remove window from master list
 		remove_uiwin(w);
+		// delete window (curses)
 		ASSERT(uiw_win(w));
 		delwin(uiw_win(w));
+		// delete boxwin (curses)
+		if (uiw_boxwin(w))
+			delwin(uiw_boxwin(w));
+		// delete window name
 		ASSERT(w->name);
 		stdfree((STRING)w->name);
+		// delete window
 		stdfree(w);
 		*uiw = 0;
 	}

--- a/src/liflines/screen.c
+++ b/src/liflines/screen.c
@@ -489,6 +489,10 @@ remove_uiwin (UIWINDOW uiwin)
 	BOOLEAN deleteall = FALSE;
 	ASSERT(list_uiwin);
 	find_delete_list_elements(list_uiwin, param, &does_match, deleteall);
+	// If the list is empty, then delete the list.  This avoids a memory leak.
+	// The list will be created again in add_uiwin if needed.
+	if (is_empty_list(list_uiwin))
+		destroy_empty_list(list_uiwin);
 }
 /*==========================================
  * does_match -- Used as callback to remove_uiwin


### PR DESCRIPTION
These were discovered by starting LifeLines, creating an empty database, and then exiting LifeLines.
Added a valgrind wrapper script with suppressions for ncurses memory leaks.