### PR TITLE
screen.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/liflines/screen.c
+++ b/src/liflines/screen.c
@@ -425,9 +425,9 @@ repaint_main_menu (UIWINDOW uiwin)
 	str = getlloptint("FullDbPath", 1) ? readpath : readpath_file;
 	mvccwprintw(win, 3, 4, _(qSdbname), str);
 	if (immutable)
-		wprintw(win, _(qSdbimmut));
+		wprintw(win, "%s", _(qSdbimmut));
 	else if (readonly)
-		wprintw(win, _(qSdbrdonly));
+		wprintw(win, "%s", _(qSdbrdonly));
 	row = 5;
 	/* i18n problem: the letters are not being read from the menu strings */
 	mvccwaddstr(win, row++, 2, _(qSplschs));


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    screen.c:430:17: error: format not a string literal and no format arguments [-Werror=format-security]
      430 |                 wprintw(win, _(qSdbrdonly));
          |                 ^~~~~~~

Let's wrap all the missing places with "%s" format. It should be fine
for this case as format string don't contain any format arguments.