### PR TITLE
Use global rules in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,6 @@
 **/Makefile
 **/Makefile.in
 
-# build artifacts
-**/*.[oa]
-**/.deps
-
 ##
 ## ROOT DIRECTORY PATTERNS
 ##

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,32 @@
-Makefile
-Makefile.in
-.linesrc
-lines.cfg
+##
+## GLOBAL PATTERNS
+##
+
+# editor temp files
+**/*~
+**/*.swp
+
+# MacOSX
+**/.DS_Store
+
+# generated makefiles
+**/Makefile
+**/Makefile.in
+
+# build artifacts
+**/*.[oa]
+**/.deps
+
+##
+## ROOT DIRECTORY PATTERNS
+##
+
+# generated configure scripts
 aclocal.m4
 autom4te.cache
-config.*
 configure
 stamp-h1
-build/autotools/compile
-*~
-*.swp
-.DS_Store
+
+# configuration files
+.linesrc
+lines.cfg

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/docs/editor/.gitignore
+++ b/docs/editor/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/docs/man/.gitignore
+++ b/docs/man/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/docs/manual/.gitignore
+++ b/docs/manual/.gitignore
@@ -1,6 +1,3 @@
-Makefile
-Makefile.in
-
 ll-devguide.pdf
 ll-devguide.txt
 ll-devguide.html

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,5 +1,3 @@
-Makefile
-Makefile.in
 POTFILES
 lifelines.pot
 *.gmo

--- a/reports/.gitignore
+++ b/reports/.gitignore
@@ -1,6 +1,3 @@
-Makefile
-Makefile.in
-*.o
 bib2html
 bury
 index.html

--- a/reports/st/.gitignore
+++ b/reports/st/.gitignore
@@ -1,9 +1,2 @@
-Makefile
-Makefile.in
-test_forindi.out
-test_forfam.out
-test_indi_it.out
-test_fam_it.out
-test_othr_it.out
-st_all.out
-st_all.stdout
+*.out
+*.stdout

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,7 @@
+##
+## GLOBAL PATTERNS FOR SRC
+##
+
+# build artifacts
+**/*.[oa]
+**/.deps

--- a/src/arch/.gitignore
+++ b/src/arch/.gitignore
@@ -1,4 +1,0 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps

--- a/src/arch/mswin/.gitignore
+++ b/src/arch/mswin/.gitignore
@@ -1,3 +1,0 @@
-Makefile
-Makefile.in
-*.o

--- a/src/btree/.gitignore
+++ b/src/btree/.gitignore
@@ -1,4 +1,0 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps

--- a/src/gedlib/.gitignore
+++ b/src/gedlib/.gitignore
@@ -1,4 +1,0 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps

--- a/src/hdrs/.gitignore
+++ b/src/hdrs/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/src/hdrs/mswin/.gitignore
+++ b/src/hdrs/mswin/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in

--- a/src/interp/.gitignore
+++ b/src/interp/.gitignore
@@ -1,6 +1,2 @@
-Makefile
-Makefile.in
-*.[oa]
 yacc.[ch]
 yacc.output
-.deps

--- a/src/liflines/.gitignore
+++ b/src/liflines/.gitignore
@@ -1,6 +1,2 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps
 llines
 llexec

--- a/src/stdlib/.gitignore
+++ b/src/stdlib/.gitignore
@@ -1,4 +1,0 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps

--- a/src/tools/.gitignore
+++ b/src/tools/.gitignore
@@ -1,7 +1,3 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps
 btedit
 dbverify
 lldump

--- a/src/ui/.gitignore
+++ b/src/ui/.gitignore
@@ -1,4 +1,0 @@
-Makefile
-Makefile.in
-*.[oa]
-.deps

--- a/tt/.gitignore
+++ b/tt/.gitignore
@@ -1,2 +1,0 @@
-Makefile
-Makefile.in


### PR DESCRIPTION
Add global rules in src/.gitignore which allows many of the .gitignore files under src/ to be removed.
Minor modifications to .gitignore which allows many of the other .gitignore files to be simplified or removed.