### PR TITLE
Update configure to look for expect, and skip tests that require it when not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ case $host in
     ;;
 esac
 
-dnl Specify bit width if requrested
+dnl Specify bit width if requested
 AC_ARG_WITH(32bit,
     [  --with-32bit             Build in 32-bit mode ],
     [build_32bit=$withval],
@@ -132,6 +132,21 @@ then
 fi
 
 dnl **************************************************************
+dnl Handle testing requirements
+dnl **************************************************************
+
+dnl Some tests need the 'expect' program.
+echo "Looking for expect"
+AC_PATH_PROG(TOOL_EXPECT, expect, FAIL)
+if test "$TOOL_EXPECT" = "FAIL"; then
+    AC_MSG_RESULT( ************************************************************************ )
+    AC_MSG_RESULT( ******** Cannot find expect.  Some tests will be skipped. ************** )
+    AC_MSG_RESULT( ************************************************************************ )
+fi
+
+AM_CONDITIONAL(HAVE_EXPECT, test "$TOOL_EXPECT" != "FAIL")
+
+dnl **************************************************************
 dnl Handle Docs Target
 dnl **************************************************************
 
@@ -149,14 +164,14 @@ then
         AC_MSG_RESULT( ************************************************************************ )
         AC_MSG_RESULT( ******** Cannot find xmlto to build docs.  Will not build docs. ******** )
         AC_MSG_RESULT( ************************************************************************ )
-        build_docs=no 
+        build_docs=no
     fi
     AC_PATH_PROG(TOOL_DBLATEX, dblatex, FAIL)
     if test "$TOOL_DBLATEX" = "FAIL"; then
         AC_MSG_RESULT( ************************************************************************ )
         AC_MSG_RESULT( ******* Cannot find dblatex to build docs.  Will not build docs. ******* )
         AC_MSG_RESULT( ************************************************************************ )
-        build_docs=no 
+        build_docs=no
     fi
 fi
 
@@ -193,7 +208,7 @@ AC_CHECK_HEADERS( wchar.h wctype.h )
 AC_CHECK_HEADERS( math.h )
 
 echo Looking for library functions
-AC_CHECK_FUNCS( _vsnprintf heapwalk _heapwalk getpwuid setlocale )
+AC_CHECK_FUNCS( _vsnprintf getpwuid setlocale )
 AC_CHECK_FUNCS( wcscoll towlower towupper iswspace iswalpha )
 AC_SEARCH_LIBS( sin, m )
 AC_SEARCH_LIBS( cos, m )
@@ -201,6 +216,24 @@ AC_SEARCH_LIBS( tan, m )
 AC_SEARCH_LIBS( asin, m )
 AC_SEARCH_LIBS( acos, m )
 AC_SEARCH_LIBS( atan, m )
+
+echo Looking for header files and libraries to support heap walking
+dnl We need to cheat on OSX/Darwin.  The standard configure
+dnl check brings in a C++ header which bombs and causes
+dnl configure to display a particularly nasty warning, which
+dnl we don't want to expose to end-users.
+case $host in
+  *apple-darwin*)
+    HAVE_ALLOC_H=no
+    HAVE_MALLOC_H=no
+    HAVE_HEAPWALK=no
+    HAVE__HEAPWALK=no
+    ;;
+  *)
+    AC_CHECK_HEADERS( alloc.h malloc.h )
+    AC_CHECK_FUNCS( heapwalk _heapwalk )
+    ;;
+esac
 
 dnl **************************************************************
 dnl Check for curses
@@ -250,7 +283,7 @@ echo Looking for curses headers
 AC_CHECK_HEADERS( ncursesw/curses.h ncurses/curses.h curses.h )
 
 dnl **************************************************************
-dnl Check for Replacement Fucntions for Standard Libraries/Curses
+dnl Check for Replacement Functions for Standard Libraries/Curses
 dnl **************************************************************
 
 echo Checking for replacement functions
@@ -262,26 +295,8 @@ dnl Standard libraries - curses
 AC_REPLACE_FUNCS( has_key )
 
 dnl **************************************************************
-dnl Platform/Version-Specific Checks
+dnl Platform-Specific Configuration
 dnl **************************************************************
-
-echo Looking for header files and libraries to support heap walking
-dnl We need to cheat on OSX/Darwin.  The standard configure
-dnl check brings in a C++ header which bombs and causes
-dnl configure to display a particularly nasty warning, which
-dnl we don't want to expose to end-users.
-case $host in
-  *apple-darwin*)
-    HAVE_ALLOC_H=no
-    HAVE_MALLOC_H=no
-    HAVE_HEAPWALK=no
-    HAVE__HEAPWALK=no
-    ;;
-  *)
-    AC_CHECK_HEADERS( alloc.h malloc.h )
-    AC_CHECK_FUNCS( heapwalk _heapwalk )
-    ;;
-esac
 
 case $host_os in
   *windows*)
@@ -293,7 +308,7 @@ case $host_os in
 esac
 
 dnl **************************************************************
-dnl Build Makefiles
+dnl Generate Makefiles
 dnl **************************************************************
 
 AC_OUTPUT(Makefile \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,8 @@ testsubdir              = date gengedcomstrong interp math pedigree-longname \
 
 TESTS_ENVIRONMENT       = top_builddir=$(top_builddir)
 
-TESTS   =               date/checkjd2date.llscr         \
+# Tests that have no external dependencies
+TESTS1  =               date/checkjd2date.llscr         \
 			gengedcomstrong/test1.llscr     \
 			interp/eqv_pvalue.llscr         \
 			interp/fullname.llscr           \
@@ -22,11 +23,18 @@ TESTS   =               date/checkjd2date.llscr         \
 			string/mc_llexec1.llscr         \
 			string/mc_llines.llscr          \
 			string/mc_llines1.llscr         \
-			string/mc_llines2.llscr         \
 			view-history/view-history.llscr \
 			Royal92/Royal92.llscr           \
 			Royal92/Analyze.llscr           \
 			Royal92/check_lltest.llscr 
+
+# Tests that depend on 'expect'
+if HAVE_EXPECT
+TESTS2	=		string/mc_llines2.llscr
+endif
+
+TESTS	=		$(TESTS1) $(TESTS2)
+
 # make runs run_a_test file.llscr to generate file.log
 TEST_EXTENSIONS = .llscr
 LLSCR_LOG_COMPILER = $(srcdir)/run_a_test

--- a/tests/run_a_test
+++ b/tests/run_a_test
@@ -149,10 +149,6 @@ function run_a_command {
             if [[ $ret < "1" ]] ; then
                 ret=1
             fi
-            # expect is now optional package for debian (required for redhat)
-            if [[ $cmd = expect* ]] ; then
-                echo "make sure the package containing $cmd is loaded on your system"
-            fi
             exit 99
         else
             echo "$thistest Warning post command '$cmd' found outside build tree"
@@ -258,7 +254,7 @@ function run_a_command {
             echo "$cmpmsg"
         fi
     else
-        # CAPTUREOUT not is set and file is llines 
+        # CAPTUREOUT is not set and file is llines or expect
         # do compare anyway, but only report results as SKIP
         # and don't count failures
         compare_file $stdout_name


### PR DESCRIPTION
Fixes #450 