### PR TITLE
Clean up some more compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,7 @@ dnl **************************************************************
 
 dnl Add warning flags when using The GNU C Compiler
 if test "${ac_cv_prog_gcc}" = "yes"; then
-  CFLAGS="${CFLAGS} -W -Wall"
+  CFLAGS="${CFLAGS} -W -Wall -Wextra"
   CFLAGS="${CFLAGS} -Wcast-align -Wmissing-declarations -Wmissing-prototypes"
   CFLAGS="${CFLAGS} -Wreturn-type -Wstrict-prototypes -pedantic"
 

--- a/src/arch/has_key.c
+++ b/src/arch/has_key.c
@@ -11,8 +11,7 @@
  *  contains a special hardware key code
  * Created: 2003/01/02 (Perry Rapp)
  *===============================================*/
-int has_key(int ch)
+int has_key(HINT_PARAM_UNUSED int ch)
 {
-	ch=ch; /* unused */
 	return 0;
 }

--- a/src/btree/opnbtree.c
+++ b/src/btree/opnbtree.c
@@ -476,7 +476,7 @@ getlldberrstr (BTERR errnum)
 {
 	STRING err = "";
 
-	if (errnum > BTERR_MIN || errnum < BTERR_MAX)
+	if ((errnum > BTERR_MIN) && (errnum < BTERR_MAX))
 		err = lldberrstr[errnum].errstr;
 
 	return err;

--- a/src/gedlib/dateparse.c
+++ b/src/gedlib/dateparse.c
@@ -717,11 +717,10 @@ gdateval_isdual (GDATEVAL gdv)
  * Created: 2001/12/28 (Perry Rapp)
  *===========================*/
 static BOOLEAN
-is_valid_day (struct tag_gdate * pdate, struct tag_dnum day)
+is_valid_day (HINT_PARAM_UNUSED struct tag_gdate * pdate, struct tag_dnum day)
 {
 	/* To consider: Fancy code with calendars */
 	/* for now, use max (all cals all months), which is 31 */
-	pdate=pdate; /* unused */
 	return (day.val>=1 && day.val2<=31);
 }
 /*=============================

--- a/src/gedlib/editvtab.c
+++ b/src/gedlib/editvtab.c
@@ -139,12 +139,11 @@ edit_valtab_impl (TABLE *ptab, INT sep, STRING ermsg, STRING (*validator)(TABLE 
  * Created: 2001/07/22 (Perry Rapp)
  *============================================*/
 static STRING
-trans_edin (STRING input, INT len)
+trans_edin (STRING input, HINT_PARAM_UNUSED INT len)
 {
 	XLAT ttmi = transl_get_predefined_xlat(MEDIN); /* editor to internal */
 	ZSTR zstr = translate_string_to_zstring(ttmi, input);
 	STRING str = strdup(zs_str(zstr));
-	len=len; /* unused */
 	zs_free(&zstr);
 	return str;
 }
@@ -156,12 +155,11 @@ trans_edin (STRING input, INT len)
  * Created: 2001/07/22 (Perry Rapp)
  *============================================*/
 static STRING
-trans_ined (STRING input, INT len)
+trans_ined (STRING input, HINT_PARAM_UNUSED INT len)
 {
 	XLAT ttmo = transl_get_predefined_xlat(MINED);
 	ZSTR zstr = translate_string_to_zstring(ttmo, input);
 	STRING str = strdup(zs_str(zstr));
-	len=len; /* unused */
 	zs_free(&zstr);
 	return str;
 }

--- a/src/gedlib/gedcom.c
+++ b/src/gedlib/gedcom.c
@@ -274,7 +274,7 @@ nkey_load_key (NKEY * nkey)
 	if (nkey->key[0])
 		return;
 	snprintf(key, MAXKEYWIDTH, "%c" FMT_INT, nkey->ntype, nkey->keynum);
-	strncpy(nkey->key, key, MAXKEYWIDTH);
+	strncpy(nkey->key, key, sizeof(nkey->key));
 }
 /*==================================================
  * nkey_eq -- compare two NKEYs

--- a/src/gedlib/gstrings.c
+++ b/src/gedlib/gstrings.c
@@ -210,12 +210,11 @@ sour_to_list_string (NODE sour, INT len, STRING delim)
  * Created: 2001/12/16, Perry Rapp
  *==============================================*/
 STRING
-even_to_list_string (NODE even, INT len, STRING delim)
+even_to_list_string (NODE even, INT len, HINT_PARAM_UNUSED STRING delim)
 {
 	char scratch[1024];
 	STRING name, p=scratch;
 	INT mylen=len;
-	delim=delim; /* unused */
 	if (mylen>(INT)sizeof(scratch))
 		mylen=sizeof(scratch);
 	p[0]=0;
@@ -304,13 +303,12 @@ fam_to_list_string (NODE fam, INT len, STRING delim)
  * Created: 2000/11/29, Perry Rapp
  *==============================================*/
 STRING
-other_to_list_string(NODE node, INT len, STRING delim)
+other_to_list_string(NODE node, INT len, HINT_PARAM_UNUSED STRING delim)
 {
 	char scratch[1024];
 	STRING name, p=scratch;
 	INT mylen=len;
 	NODE child;
-	delim=delim; /* unused */
 	if (mylen>(INT)sizeof(scratch))
 		mylen=sizeof(scratch);
 	p[0]=0;

--- a/src/gedlib/indiseq.c
+++ b/src/gedlib/indiseq.c
@@ -675,9 +675,8 @@ name_compare (SORTEL el1, SORTEL el2, VPTR param)
  * also used for integer value sort
  *==============================*/
 INT
-key_compare (SORTEL el1, SORTEL el2, VPTR param)
+key_compare (SORTEL el1, SORTEL el2, HINT_PARAM_UNUSED VPTR param)
 {
-	param = param; /* unused */
 	return spri(el1) - spri(el2);
 }
 /*===========================================
@@ -702,10 +701,9 @@ canonkey_order (char c)
  * Created: 2001/01/06, Perry Rapp
  *==============================*/
 static INT
-canonkey_compare (SORTEL el1, SORTEL el2, VPTR param)
+canonkey_compare (SORTEL el1, SORTEL el2, HINT_PARAM_UNUSED VPTR param)
 {
 	char c1=skey(el1)[0], c2=skey(el2)[0];
-	param = param; /* unused */
 	if (c1 == c2)
 		return spri(el1) - spri(el2);
 	return canonkey_order(c1) - canonkey_order(c2);
@@ -821,9 +819,8 @@ update_locale (INDISEQ seq)
  * valuesort_indiseq -- Sort sequence by value
  *==========================================*/
 void
-valuesort_indiseq (INDISEQ seq, BOOLEAN *eflg)
+valuesort_indiseq (INDISEQ seq, HINT_PARAM_UNUSED BOOLEAN *eflg)
 {
-	eflg = eflg; /* unused */
 	if ((IFlags(seq) & VALUESORT) && is_locale_current(seq)) return;
 	partition_sort(IData(seq), ISize(seq), value_compare, seq);
 	IFlags(seq) &= ~ALLSORTS;
@@ -2190,9 +2187,8 @@ default_create_gen_value (INT gen, INT * valtype)
  * Created: 2002/02/19, Perry Rapp
  *=========================================================*/
 INT
-default_compare_values (VPTR ptr1, VPTR ptr2, INT valtype)
+default_compare_values (VPTR ptr1, VPTR ptr2, HINT_PARAM_UNUSED INT valtype)
 {
-	valtype = valtype; /* unused */
 	/* We don't know how to deal with ptrs here */
 	/* Let's just sort them in memory order */
 	return (INTPTR)ptr1 - (INTPTR)ptr2;

--- a/src/gedlib/init.c
+++ b/src/gedlib/init.c
@@ -243,9 +243,8 @@ is_codeset_utf8 (CNSTRING codename)
  * dependent on user options
  *=================================================*/
 void
-update_useropts (VPTR uparm)
+update_useropts (HINT_PARAM_UNUSED VPTR uparm)
 {
-	uparm = uparm; /* unused */
 	if (suppress_reload)
 		return;
 	/* deal with db-specific options */

--- a/src/gedlib/llgettext.c
+++ b/src/gedlib/llgettext.c
@@ -174,7 +174,11 @@ init_win32_gettext_shim (void)
  * Created: 2002/11/28 (Perry Rapp)
  *===============================*/
 void
+#if ENABLE_NLS
 set_gettext_codeset (CNSTRING domain, CNSTRING codeset)
+#else
+set_gettext_codeset (HINT_UNUSED_PARAM CNSTRING domain, HINT_UNUSED_PARAM CNSTRING codeset)
+#endif
 {
 #if ENABLE_NLS
 	if (eqstr_ex(gt_codeset, codeset))
@@ -202,9 +206,6 @@ set_gettext_codeset (CNSTRING domain, CNSTRING codeset)
 	bind_textdomain_codeset(domain, gt_codeset);
 	if (eqstr(domain, PACKAGE))
 		locales_notify_uicodeset_changes();
-#else
-	domain = domain; /* unused */
-	codeset = codeset; /* unused */
 #endif /* ENABLE_NLS */
 }
 /*=================================

--- a/src/gedlib/locales.c
+++ b/src/gedlib/locales.c
@@ -458,7 +458,11 @@ is_msgcategory (int category)
  * win32_setlocale -- handle MS-Windows goofed up locale names
  *========================================*/
 static char *
+#if defined(_WIN32) && !defined(__CYGWIN__)
 win32_setlocale (int category, char * locale)
+#else
+win32_setlocale (HINT_PARAM_UNUSED int category, HINT_PARAM_UNUSED char * locale)
+#endif
 {
 	char * rtn = 0;
 #if defined(_WIN32) && !defined(__CYGWIN__)
@@ -489,9 +493,6 @@ win32_setlocale (int category, char * locale)
 		at least unless int_codeset == 0 */
 		rtn = setlocale(category, w32loc);
 	}
-#else
-	category=category; /* unused */
-	locale=locale; /* unused */
 #endif /* _WIN32 */
 	return rtn;
 }

--- a/src/gedlib/names.c
+++ b/src/gedlib/names.c
@@ -1229,11 +1229,10 @@ typedef struct
 } TRAV_NAME_PARAM;
 /* see above */
 static BOOLEAN
-traverse_name_callback (RKEY rkey, STRING data, INT len, void *param)
+traverse_name_callback (RKEY rkey, STRING data, HINT_PARAM_UNUSED INT len, void *param)
 {
 	TRAV_NAME_PARAM *tparam = (TRAV_NAME_PARAM *)param;
 	INT i;
-	len=len; /* unused */
 
 	parsenamerec(&rkey, data);
 

--- a/src/gedlib/nodeio.c
+++ b/src/gedlib/nodeio.c
@@ -432,11 +432,10 @@ next_fp_to_node (FILE *fp, BOOLEAN list, XLAT ttm,
  * returns addref'd record
  *==========================================*/
 RECORD
-string_to_record (STRING str, CNSTRING key, INT len)
+string_to_record (STRING str, CNSTRING key, HINT_PARAM_UNUSED INT len)
 {
 	RECORD rec = 0;
 	NODE node = 0;
-	len=len; /* unused */
 
 	/* we must fill in the top field */
 

--- a/src/gedlib/refns.c
+++ b/src/gedlib/refns.c
@@ -802,7 +802,6 @@ traverse_refn_callback ( TRAV_RECORD_FUNC_BYKEY_ARGS(rkey, data, len, param) )
 {
 	TRAV_REFN_PARAM *tparam = (TRAV_REFN_PARAM *)param;
 	INT i;
-	len=len; /* unused */
 
 	parserefnrec(rkey, data);
 

--- a/src/gedlib/remove.c
+++ b/src/gedlib/remove.c
@@ -244,9 +244,8 @@ remove_spouse (NODE indi, NODE fam)
  * Created: 2005/01/08, Perry Rapp
  *==============================================================*/
 BOOLEAN
-remove_fam_record (RECORD frec)
+remove_fam_record (HINT_PARAM_UNUSED RECORD frec)
 {
-	frec=frec; /* unused */
 	message("%s", _("Families may not yet be removed in this fashion."));
 	return FALSE;
 }

--- a/src/gedlib/valid.c
+++ b/src/gedlib/valid.c
@@ -221,7 +221,7 @@ valid_node_type (NODE node, char ntype, STRING *pmsg, NODE node0)
  *  orig:  [IN]  SOUR node to match 
  *====================================*/
 BOOLEAN
-valid_sour_tree (NODE node, STRING *pmsg, NODE orig)
+valid_sour_tree (NODE node, STRING *pmsg, HINT_PARAM_UNUSED NODE orig)
 {
 	*pmsg = NULL;
 	if (!node) {
@@ -249,7 +249,7 @@ valid_sour_tree (NODE node, STRING *pmsg, NODE orig)
  *  orig:  [IN]  EVEN node to match
  *====================================*/
 BOOLEAN
-valid_even_tree (NODE node, STRING *pmsg, NODE orig)
+valid_even_tree (NODE node, STRING *pmsg, HINT_PARAM_UNUSED NODE orig)
 {
 	*pmsg = NULL;
 	if (!node) {
@@ -277,7 +277,7 @@ valid_even_tree (NODE node, STRING *pmsg, NODE orig)
  *  orig:  [IN]  OTHR node to match
  *====================================*/
 BOOLEAN
-valid_othr_tree (NODE node, STRING *pmsg, NODE orig)
+valid_othr_tree (NODE node, STRING *pmsg, HINT_PARAM_UNUSED NODE orig)
 {
 	*pmsg = NULL;
 	if (!node) {

--- a/src/gedlib/xlat.c
+++ b/src/gedlib/xlat.c
@@ -726,9 +726,8 @@ xl_is_xlat_valid (XLAT xlat)
  * Created: 2002/12/15 (Perry Rapp)
  *========================================================*/
 void
-xl_release_xlat (XLAT xlat)
+xl_release_xlat (HINT_PARAM_UNUSED XLAT xlat)
 {
-	xlat=xlat; /* unused */
 	/*
 	TODO: If it is an adhoc xlat, free it
 	Have to remove it from cache list, which is slightly annoying

--- a/src/hdrs/btree.h
+++ b/src/hdrs/btree.h
@@ -209,7 +209,7 @@ typedef BOOLEAN(*TRAV_INDEX_FUNC)(BTREE, INDEX, void*);
 typedef BOOLEAN(*TRAV_BLOCK_FUNC)(BTREE, BLOCK, void*);
 
 typedef BOOLEAN(*TRAV_RECORD_FUNC_BYKEY)(RKEY, STRING, INT, void*);
-#define TRAV_RECORD_FUNC_BYKEY_ARGS(a,b,c,d) RKEY a, STRING b, INT c, void* d
+#define TRAV_RECORD_FUNC_BYKEY_ARGS(a,b,c,d) RKEY a, STRING b, HINT_PARAM_UNUSED INT c, void* d
 
 /*====================================
  * BTREE library function declarations 

--- a/src/hdrs/btree.h
+++ b/src/hdrs/btree.h
@@ -63,8 +63,8 @@ typedef struct {
 
 #define RKEY_NULL "\0\0\0\0\0\0\0\0"
 #define RKEY_INIT(r) memcpy((r).r_rkey, RKEY_NULL, RKEYLEN)
-#define RKEY_IS_NULL(r) memcmp((r).r_rkey, RKEY_NULL, RKEYLEN)
-#define RKEY_AS_INT64(r,v) memcpy(&(v), (r).r_rkey, RKEYLEN);
+#define RKEY_IS_NULL(r) (memcmp((r).r_rkey, RKEY_NULL, RKEYLEN) == 0)
+#define RKEY_AS_INT64(r,v) memcpy(&(v), (r).r_rkey, RKEYLEN)
 
 typedef INT32 FKEY; /*file key*/
 

--- a/src/hdrs/btree.h
+++ b/src/hdrs/btree.h
@@ -63,6 +63,8 @@ typedef struct {
 
 #define RKEY_NULL "\0\0\0\0\0\0\0\0"
 #define RKEY_INIT(r) memcpy((r).r_rkey, RKEY_NULL, RKEYLEN)
+#define RKEY_IS_NULL(r) memcmp((r).r_rkey, RKEY_NULL, RKEYLEN)
+#define RKEY_AS_INT64(r,v) memcpy(&(v), (r).r_rkey, RKEYLEN);
 
 typedef INT32 FKEY; /*file key*/
 

--- a/src/hdrs/gedcom.h
+++ b/src/hdrs/gedcom.h
@@ -126,13 +126,13 @@ typedef BOOLEAN(*TRAV_RAWRECORDS_FUNC)(CNSTRING key, STRING data, INT len, void 
 #define TRAV_RAWRECORDS_FUNC_ARGS(zkey,zdata,zlen,zparam) CNSTRING zkey, STRING zdata, INT zlen, void *zparam
 
 typedef BOOLEAN(*TRAV_RECORDS_FUNC)(CNSTRING key, RECORD rec, void *param);
-#define TRAV_RECORDS_FUNC_ARGS(zkey,zrec,zparam) CNSTRING zkey, RECORD zrec, void *zparam
+#define TRAV_RECORDS_FUNC_ARGS(zkey,zrec,zparam) CNSTRING zkey, RECORD zrec, HINT_PARAM_UNUSED void *zparam
 
 typedef BOOLEAN(*TRAV_NAMES_FUNC)(CNSTRING key, CNSTRING name, BOOLEAN newset, void *param);
-#define TRAV_NAMES_FUNC_ARGS(zkey,zname,znewset,zparam) CNSTRING zkey, CNSTRING zname, BOOLEAN znewset, void *zparam
+#define TRAV_NAMES_FUNC_ARGS(zkey,zname,znewset,zparam) CNSTRING zkey, CNSTRING zname, BOOLEAN znewset, HINT_PARAM_UNUSED void *zparam
 
 typedef BOOLEAN(*TRAV_REFNS_FUNC)(CNSTRING key, CNSTRING refn, BOOLEAN newset, void *param);
-#define TRAV_REFNS_FUNC_ARGS(zkey,zrefn,znewset,zparam) CNSTRING zkey, CNSTRING zrefn, BOOLEAN znewset, void *zparam
+#define TRAV_REFNS_FUNC_ARGS(zkey,zrefn,znewset,zparam) CNSTRING zkey, CNSTRING zrefn, BOOLEAN znewset, HINT_PARAM_UNUSED void *zparam
 
 /*=====================================
  * LLDATABASE types -- LifeLines database

--- a/src/interp/builtin.c
+++ b/src/interp/builtin.c
@@ -275,13 +275,10 @@ llrpt_gettext (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: gettoday() --> EVENT
  *=================================*/
 PVALUE
-llrpt_gettoday (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_gettoday (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, HINT_PARAM_UNUSED BOOLEAN *eflg)
 {
 	NODE prnt = create_temp_node(NULL, "EVEN", NULL, NULL);
 	NODE chil = create_temp_node(NULL, "DATE", get_todays_date(), prnt);
-	node=node; /* unused */
-	stab=stab; /* unused */
-	eflg=eflg; /* unused */
 
 	nchild(prnt) = chil;
 	return create_pvalue_from_node(prnt);
@@ -3483,10 +3480,8 @@ copyfile_end:
  * usage: nl() -> STRING
  *=======================*/
 PVALUE
-llrpt_nl (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_nl (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_string("\n");
 }
@@ -3495,10 +3490,8 @@ llrpt_nl (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: sp() -> STRING
  *========================*/
 PVALUE
-llrpt_space (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_space (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_string(" ");
 }
@@ -3507,10 +3500,8 @@ llrpt_space (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: qt() -> STRING
  *============================*/
 PVALUE
-llrpt_qt (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_qt (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_string("\"");
 }

--- a/src/interp/builtin_list.c
+++ b/src/interp/builtin_list.c
@@ -246,9 +246,8 @@ llrpt_dequeue (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  *  Created: 2002/12/29 (Perry Rapp)
  *=================================*/
 static VPTR
-create_list_value_pvalue (LIST list)
+create_list_value_pvalue (HINT_PARAM_UNUSED LIST list)
 {
-	list=list; /* unused */
 	return create_pvalue_any();
 }
 /*==================================+

--- a/src/interp/heapused.c
+++ b/src/interp/heapused.c
@@ -62,7 +62,7 @@
  * usage: heapused() -> INT
  *==============================================*/
 PVALUE
-llrpt_heapused (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_heapused (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
 #if defined(WORKING_HEAPUSED)
 	HEAPINFO hi;
@@ -71,8 +71,6 @@ llrpt_heapused (PNODE node, SYMTAB stab, BOOLEAN *eflg)
 	long heapcnt;
 	int repcnt;
 	static FILE *errfp = NULL;
-	node=node; /* unused */
-	stab=stab; /* unused */
 
 	if(errfp == NULL) errfp = fopen("pbm.err", LLWRITETEXT);
 
@@ -98,9 +96,7 @@ llrpt_heapused (PNODE node, SYMTAB stab, BOOLEAN *eflg)
 
 	return create_pvalue_from_int(heapfree);
 #else
-	/* Unsupported, what should we do? return error or give bogus value? */
-	node=node; /* unused */
-	stab=stab; /* unused */
+	/* Unsupported, return error. */
 	*eflg = TRUE;
 	return NULL;
 #endif

--- a/src/interp/interp.c
+++ b/src/interp/interp.c
@@ -436,9 +436,8 @@ wipe_pactx (PACTX pactx)
  * remove_tables -- Remove interpreter's tables
  *==========================================*/
 static void
-remove_tables (PACTX pactx)
+remove_tables (HINT_PARAM_UNUSED PACTX pactx)
 {
-	pactx=pactx; /* unused */
 	destroy_table(gproctab);
 	gproctab=NULL;
 	remove_symtab(globtab);
@@ -1908,10 +1907,9 @@ pa_handle_option (CNSTRING optname)
  * Called directly from generated parser code (ie, from code in yacc.y)
  *=============================================*/
 void
-pa_handle_char_encoding (PACTX pactx, PNODE node)
+pa_handle_char_encoding (HINT_PARAM_UNUSED PACTX pactx, PNODE node)
 {
 	CNSTRING codeset = get_internal_string_node_value(node);
-	pactx=pactx; /* unused */
 	strupdate(&irptinfo(node)->codeset, codeset);
 }
 /*=============================================+
@@ -1939,14 +1937,13 @@ make_internal_string_node (PACTX pactx, STRING str)
  *  parse-time handling of report command
  *=============================================*/
 void
-pa_handle_include (PACTX pactx, PNODE node)
+pa_handle_include (HINT_PARAM_UNUSED PACTX pactx, PNODE node)
 {
 	/*STRING fname = ifname(node); */ /* current file */
 	CNSTRING newfname = get_internal_string_node_value(node);
 	STRING fullpath=0, localpath=0;
 	ZSTR zstr=0;
 	PATHINFO pathinfo = 0;
-	pactx=pactx; /* unused */
 
 	/* if it is relative, get local path to give to find_program */
 	if (!is_path(newfname)) {
@@ -1969,12 +1966,11 @@ pa_handle_include (PACTX pactx, PNODE node)
  *  node:  [IN]  current parse node
  *=============================================*/
 void
-pa_handle_require (PACTX pactx, PNODE node)
+pa_handle_require (HINT_PARAM_UNUSED PACTX pactx, PNODE node)
 {
 	CNSTRING reqver = get_internal_string_node_value(node);
 	STRING propstr = "requires_lifelines-reports.version:";
 	TABLE tab=0;
-	pactx=pactx; /* unused */
 
 	tab = (TABLE)valueof_obj(pactx->filetab, pactx->fullpath);
 	if (!tab) {

--- a/src/interp/more.c
+++ b/src/interp/more.c
@@ -768,10 +768,8 @@ llrpt_runsystem (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: firstindi() -> INDI
  *===========================================*/
 PVALUE
-llrpt_firstindi (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_firstindi (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_indi_keynum(xref_firsti());
 }
@@ -824,10 +822,8 @@ llrpt_previndi (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: lastindi() -> INDI
  *=========================================*/
 PVALUE
-llrpt_lastindi (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_lastindi (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_indi_keynum(xref_lasti());
 }
@@ -836,10 +832,8 @@ llrpt_lastindi (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: firstfam() -> FAM
  *==========================================*/
 PVALUE
-llrpt_firstfam (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_firstfam (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_fam_keynum(xref_firstf());
 }
@@ -892,10 +886,8 @@ llrpt_prevfam (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: lastfam() -> FAM
  *========================================*/
 PVALUE
-llrpt_lastfam (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_lastfam (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_fam_keynum(xref_lastf());
 }
@@ -1168,10 +1160,8 @@ llrpt_genindiset (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: version() -> STRING
  *===============================================*/
 PVALUE
-llrpt_version (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_version (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_string(get_lifelines_version(120));
 }
@@ -1205,10 +1195,8 @@ llrpt_pvalue (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: program() -> STRING
  *===========================================*/
 PVALUE
-llrpt_program (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_program (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, HINT_PARAM_UNUSED BOOLEAN *eflg)
 {
-	stab=stab; /* unused */
-	eflg=eflg; /* unused */
 	return create_pvalue_from_string(irptinfo(node)->fullpath);
 }
 /*============================================+

--- a/src/interp/pvalue.c
+++ b/src/interp/pvalue.c
@@ -203,11 +203,8 @@ set_pvalue (PVALUE val, INT type, PVALUE_DATA pvd)
  * Created: 2003-02-04 (Perry Rapp)
  *======================================*/
 void
-dolock_node_in_cache (NODE node, BOOLEAN lock)
+dolock_node_in_cache (HINT_PARAM_UNUSED NODE node, HINT_PARAM_UNUSED BOOLEAN lock)
 {
-	node = node;	/* NOTUSED */
-	lock = lock;	/* NOTUSED */
-
 #if NOT_WORKING_ON_LARGE_DATA_SETS
 /* This leads to cache overflow, so there is something
 wrong here - Perry, 2003-03-07 */
@@ -332,10 +329,9 @@ clear_pv_indiseq (INDISEQ seq)
  *======================================*/
 #ifdef UNUSED
 static void
-table_pvcleaner (CNSTRING key, UNION uval)
+table_pvcleaner (HINT_PARAM_UNUSED CNSTRING key, UNION uval)
 {
 	PVALUE val = uval.w;
-	key=key; /* unused */
 	delete_pvalue(val);
 	uval.w = NULL;
 }
@@ -1195,9 +1191,8 @@ CACHEEL
 pvalue_to_cel (PVALUE val)
 {
 	RECORD rec = pvalue_to_record(val);
-	NODE root = nztop(rec); /* force record into cache */
+	HINT_VAR_UNUSED NODE root = nztop(rec); /* force record into cache */
 	CACHEEL cel = nzcel(rec);
-	root = root;	/* NOTUSED */
 	return cel;
 }
 /*==================================

--- a/src/interp/rassa.c
+++ b/src/interp/rassa.c
@@ -164,10 +164,8 @@ llrpt_pagemode (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: linemode() -> VOID
  *=======================================*/
 PVALUE
-llrpt_linemode (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_linemode (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	outputmode = BUFFERED;
 	linebuflen = 0;
 	bufptr = (STRING)linebuffer;
@@ -300,10 +298,8 @@ request_file (BOOLEAN *eflg)
  * usage: outfile() -> STRING
  *===================================*/
 PVALUE
-llrpt_outfile (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_outfile (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	if (!Poutfp) {
 		if (!request_file(eflg))
 			return NULL;
@@ -420,10 +416,8 @@ llrpt_col (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: getcol() -> INT
  *================================*/
 PVALUE
-llrpt_getcol (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_getcol (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = FALSE;
 	return create_pvalue_from_int(curcol);
 }
@@ -432,13 +426,11 @@ llrpt_getcol (PNODE node, SYMTAB stab, BOOLEAN *eflg)
  * usage: pageout() -> VOID
  *====================================================*/
 PVALUE
-llrpt_pageout (PNODE node, SYMTAB stab, BOOLEAN *eflg)
+llrpt_pageout (HINT_PARAM_UNUSED PNODE node, HINT_PARAM_UNUSED SYMTAB stab, BOOLEAN *eflg)
 {
 	char scratch[MAXCOLS+2];
 	STRING p;
 	INT row, i;
-	node=node; /* unused */
-	stab=stab; /* unused */
 	*eflg = TRUE;
 	if (outputmode != PAGEMODE) return NULL;
 	if (!Poutfp) {

--- a/src/interp/symtab.c
+++ b/src/interp/symtab.c
@@ -194,9 +194,7 @@ void
 symbol_tables_end (void)
 {
 	/* for debugging check that no symbol tables leaked */
-	INT leaked_symtabs = length_list(live_symtabs);
-	leaked_symtabs = leaked_symtabs; /* remove unused warning */
-	/* 2005-02-06, 2200Z, Perry: No leaks here */
+	HINT_VAR_UNUSED INT leaked_symtabs = length_list(live_symtabs);
 }
 /*======================================================
  * in_symtab -- Does symbol table have this entry ?

--- a/src/liflines/brwsmenu.c
+++ b/src/liflines/brwsmenu.c
@@ -615,9 +615,8 @@ register_brwsmenu_lang_callbacks (BOOLEAN registering)
  * brwsmenu_on_lang_change -- UI language or codeset has changed
  *==========================*/
 static void
-brwsmenu_on_lang_change (VPTR uparm)
+brwsmenu_on_lang_change (HINT_PARAM_UNUSED VPTR uparm)
 {
-	uparm = uparm; /* unused */
 	f_reloading = TRUE;
 	menuitem_terminate();
 	brwsmenu_initialize(0, 0); /* 0 means use stored values */

--- a/src/liflines/import.c
+++ b/src/liflines/import.c
@@ -408,10 +408,9 @@ translate_key (STRING key)    /* key does not have surrounding @ chars */
  * translate_values -- Traverse function to translate pointers
  *==========================================================*/
 static BOOLEAN
-translate_values (NODE node, VPTR param)
+translate_values (NODE node, HINT_PARAM_UNUSED VPTR param)
 {
 	STRING new;
-	param=param; /* unused */
 	if (!pointer_value(nval(node))) return TRUE;
 	new = translate_key(rmvat(nval(node)));
 	stdfree(nval(node));

--- a/src/liflines/llexec.c
+++ b/src/liflines/llexec.c
@@ -421,9 +421,8 @@ parse_arg (const char * optarg, char ** optname, char **optval)
  * shutdown_ui -- (Placeholder, we don't need it)
  *=================================================*/
 void
-shutdown_ui (BOOLEAN pause)
+shutdown_ui (HINT_PARAM_UNUSED BOOLEAN pause)
 {
-	pause=pause; /* unused */
 }
 /*==================================================
  * platform_init -- platform specific initialization

--- a/src/liflines/pedigree.c
+++ b/src/liflines/pedigree.c
@@ -527,10 +527,9 @@ node_lineprint (INT width, void * param)
  * Created: 2001/04/15, Perry Rapp
  *===============================*/
 static STRING
-tn_lineprint (INT width, void * param)
+tn_lineprint (HINT_PARAM_UNUSED INT width, void * param)
 {
 	NODE_TEXT_PRINT_PARAM ntpp = (NODE_TEXT_PRINT_PARAM)param;
-	width=width; /* unused */
 
 	return ntpp->tn->str;
 }

--- a/src/liflines/scan.c
+++ b/src/liflines/scan.c
@@ -340,12 +340,11 @@ scanner_add_result (SCANNER * scanner, CNSTRING key)
  * ns_callback -- callback for name traversal
  *=========================================*/
 static BOOLEAN
-ns_callback (CNSTRING key, CNSTRING name, BOOLEAN newset, void *param)
+ns_callback (CNSTRING key, CNSTRING name, HINT_PARAM_UNUSED BOOLEAN newset, void *param)
 {
 	INT len, ind;
 	STRING piece;
 	SCANNER * scanner = (SCANNER *)param;
-	newset=newset; /* unused */
 	if (scanner->scantype == SCAN_NAME_FULL) {
 		if (scanner_does_pattern_match(scanner, name)) {
 			scanner_add_result(scanner, key);
@@ -369,11 +368,10 @@ ns_callback (CNSTRING key, CNSTRING name, BOOLEAN newset, void *param)
  * rs_callback -- callback for refn traversal
  *=========================================*/
 static BOOLEAN
-rs_callback (CNSTRING key, CNSTRING refn, BOOLEAN newset, void *param)
+rs_callback (CNSTRING key, CNSTRING refn, HINT_PARAM_UNUSED BOOLEAN newset, void *param)
 {
 	SCANNER * scanner = (SCANNER *)param;
 	ASSERT(scanner->scantype == SCAN_REFN);
-	newset=newset; /* unused */
 
 	if (scanner_does_pattern_match(scanner, refn)) {
 		scanner_add_result(scanner, key);

--- a/src/liflines/screen.c
+++ b/src/liflines/screen.c
@@ -1094,9 +1094,8 @@ list_browse (INDISEQ seq, INT top, INT * cur, INT mark)
  *  prmpt: [IN]  prompt of question (2nd line)
  *====================================*/
 BOOLEAN
-ask_for_db_filename (CNSTRING ttl, CNSTRING prmpt, CNSTRING basedir, STRING buffer, INT buflen)
+ask_for_db_filename (CNSTRING ttl, CNSTRING prmpt, HINT_PARAM_UNUSED CNSTRING basedir, STRING buffer, INT buflen)
 {
-	basedir=basedir; /* unused */
 	/* This could have a list of existing ones like askprogram.c */
 	return ask_for_string(ttl, prmpt, buffer, buflen);
 }
@@ -1652,11 +1651,15 @@ invoke_cset_display (void)
  * add_shims_info -- Add information about gettext and iconv dlls
  *====================================*/
 static void
+#if defined WIN32_INTL_SHIM || defined WIN32_ICONV_SHIM
 add_shims_info (LIST list)
+#else
+add_shims_info (HINT_PARAM_UNUSED LIST list)
+#endif
 {
+#if defined WIN32_INTL_SHIM || defined WIN32_ICONV_SHIM
 	ZSTR zstr=zs_newn(80);
-	list=list; /* only used on MS-Windows */
-#ifdef WIN32_INTL_SHIM
+#if defined WIN32_INTL_SHIM
 	{
 		char value[MAXPATHLEN];
 		if (intlshim_get_property("dll_path", value, sizeof(value)))
@@ -1679,7 +1682,7 @@ add_shims_info (LIST list)
 		}
 	}
 #endif
-#ifdef WIN32_ICONV_SHIM
+#if defined WIN32_ICONV_SHIM
 	{
 		char value[MAXPATHLEN];
 		if (iconvshim_get_property("dll_path", value, sizeof(value)))
@@ -1703,6 +1706,7 @@ add_shims_info (LIST list)
 	}
 #endif
 	zs_free(&zstr);
+#endif
 }
 /*======================================
  * invoke_trans_menu -- menu for translation tables
@@ -3083,14 +3087,13 @@ register_screen_lang_callbacks (BOOLEAN registering)
 	}
 }
 /*============================
- * screen_on_lang_change -- UI language  or codeset has changed
+ * screen_on_lang_change -- UI language or codeset has changed
  *==========================*/
 static void
-screen_on_lang_change (VPTR uparm)
+screen_on_lang_change (HINT_PARAM_UNUSED VPTR uparm)
 {
 	LIST_ITER listit=0;
 	VPTR ptr=0;
-	uparm = uparm; /* unused */
 	listit = begin_list(list_uiwin);
 	while (next_list_ptr(listit, &ptr)) {
 		UIWINDOW uiwin = (UIWINDOW)ptr;

--- a/src/liflines/show.c
+++ b/src/liflines/show.c
@@ -396,11 +396,10 @@ show_indi_vitals (UIWINDOW uiwin, RECORD irec, LLRECT rect
  * add_spouse_line -- Add spouse line to others
  *===========================================*/
 static void
-add_spouse_line (INT num, NODE indi, NODE fam, INT width)
+add_spouse_line (HINT_PARAM_UNUSED INT num, NODE indi, NODE fam, INT width)
 {
 	STRING line, ptr=Sothers[Solen];
 	INT mylen=liwidth;
-	num=num; /* unused */
 	if (Solen >= MAXOTHERS) return;
 	if (mylen>width) mylen=width;
 	llstrcatn(&ptr, " ", &mylen);

--- a/src/liflines/valgdcom.c
+++ b/src/liflines/valgdcom.c
@@ -512,10 +512,8 @@ add_othr_defn (IMPORT_FEEDBACK ifeed, STRING xref, INT line)
  * Created: 2002-12-15 (Perry Rapp)
  *=========================================================*/
 static void
-handle_head_lev1 (IMPORT_FEEDBACK ifeed, STRING tag, STRING val, INT line)
+handle_head_lev1 (HINT_PARAM_UNUSED IMPORT_FEEDBACK ifeed, STRING tag, STRING val, HINT_PARAM_UNUSED INT line)
 {
-	ifeed=ifeed; /* unused */
-	line=line; /* unused */
 	if (eqstr(tag, "CHAR")) {
 		strupdate(&gedcom_codeset_in, (val ? val : ""));
 	}
@@ -525,12 +523,8 @@ handle_head_lev1 (IMPORT_FEEDBACK ifeed, STRING tag, STRING val, INT line)
  * Created: 2002-12-15 (Perry Rapp)
  *=========================================================*/
 static void
-handle_trlr_lev1 (IMPORT_FEEDBACK ifeed, STRING tag, STRING val, INT line)
+handle_trlr_lev1 (HINT_PARAM_UNUSED IMPORT_FEEDBACK ifeed, HINT_PARAM_UNUSED STRING tag, HINT_PARAM_UNUSED STRING val, HINT_PARAM_UNUSED INT line)
 {
-	ifeed=ifeed; /* unused */
-	tag=tag; /* unused */
-	val=val; /* unused */
-	line=line; /* unused */
 }
 /*===========================================================
  * report_missing_value -- Report line with incorrectly empty value
@@ -636,13 +630,12 @@ handle_fam_lev1 (IMPORT_FEEDBACK ifeed, STRING tag, STRING val, INT line, CNSTRI
  * check_level1_tag -- Warnings for specific tags at level 1
  *========================================================*/
 static void
-check_level1_tag (IMPORT_FEEDBACK ifeed, CNSTRING tag, CNSTRING val, INT line, CNSTRING tag0, CNSTRING xref0)
+check_level1_tag (IMPORT_FEEDBACK ifeed, CNSTRING tag, HINT_PARAM_UNUSED CNSTRING val, INT line, CNSTRING tag0, CNSTRING xref0)
 {
 	/*
 	lifelines expects lineage-linking records (FAMS, FAMC, HUSB, & WIFE)
 	to be correct, so warn if any of them occur in unusual locations
 	*/
-	val = val;    /* unused */
 	if (eqstr(tag, "FAMS")) {
 		if (!eqstr(tag0, "INDI"))
 			handle_warn(ifeed, qSlinlev1, line, tag, tag0, xref0);

--- a/src/stdlib/environ.c
+++ b/src/stdlib/environ.c
@@ -74,7 +74,11 @@ environ_determine_tempfile (void)
  * Created: 2000/12/23, Perry Rapp
  *==========================================================*/
 STRING
+#ifdef WIN32
 environ_determine_editor (INT program)
+#else
+environ_determine_editor (HINT_PARAM_UNUSED INT program)
+#endif
 {
 	STRING e;
 
@@ -90,7 +94,6 @@ environ_determine_editor (INT program)
 		if (ISNULL(e)) e = (STRING) "vi";
 	}
 #else
-	program=program; /* unused */
 	/* unix fallback is vi for all programs */
 	if (ISNULL(e)) e = (STRING) "vi";
 #endif

--- a/src/stdlib/icvt.c
+++ b/src/stdlib/icvt.c
@@ -31,7 +31,11 @@
  * iconv_can_trans -- Can iconv do this translation ?
  *=================================================*/
 BOOLEAN
+#ifdef HAVE_ICONV
 iconv_can_trans (CNSTRING src, CNSTRING dest)
+#else
+iconv_can_trans (HINT_PARAM_UNUSED CNSTRING src, HINT_PARAM_UNUSED CNSTRING dest)
+#endif
 {
 #ifdef HAVE_ICONV
 	iconv_t ict;
@@ -39,11 +43,9 @@ iconv_can_trans (CNSTRING src, CNSTRING dest)
 	ict = iconv_open(dest, src);
 	if (ict == (iconv_t)-1)
 		return FALSE;
-    iconv_close(ict);
+	iconv_close(ict);
 	return TRUE;
 #else
-	src=src; /* unused */
-	dest=dest; /* unused */
 	return FALSE;
 #endif
 }
@@ -56,7 +58,11 @@ iconv_can_trans (CNSTRING src, CNSTRING dest)
  *  illegal: [IN]  character to use as placeholder for unconvertible input
  *=================================================*/
 BOOLEAN
+#ifdef HAVE_ICONV
 iconv_trans (CNSTRING src, CNSTRING dest, CNSTRING sin, ZSTR zout, char illegal)
+#else
+iconv_trans (HINT_PARAM_UNUSED CNSTRING src, HINT_PARAM_UNUSED CNSTRING dest, HINT_PARAM_UNUSED CNSTRING sin, HINT_PARAM_UNUSED ZSTR zout, HINT_PARAM_UNUSED char illegal)
+#endif
 {
 #ifdef HAVE_ICONV
 	iconv_t ict;
@@ -191,11 +197,6 @@ icvt_terminate_and_exit:
 	iconv_close(ict);
 	return TRUE;
 #else
-	src=src; /* unused */
-	dest=dest; /* unused */
-	sin=sin; /* unused */
-	zout=zout; /* unused */
-	illegal=illegal; /* unused */
 	return FALSE;
 #endif /* HAVE_ICONV */
 }
@@ -203,12 +204,14 @@ icvt_terminate_and_exit:
  * init_win32_iconv_shim -- Helper for loading iconv.dll on win32
  *=================================================*/
 void
+#ifdef WIN32_ICONV_SHIM
 init_win32_iconv_shim (CNSTRING dllpath)
+#else
+init_win32_iconv_shim (HINT_PARAM_UNUSED CNSTRING dllpath)
+#endif
 {
 #ifdef WIN32_ICONV_SHIM
 	if (dllpath && dllpath[0])
 		iconvshim_set_property("dll_path", dllpath);
-#else
-	dllpath=dllpath; /* unused */
 #endif
 }

--- a/src/stdlib/list.c
+++ b/src/stdlib/list.c
@@ -318,12 +318,14 @@ pop_list (LIST list)
  * validate_list -- Verify list ends don't disagree
  *======================================*/
 static void
+#ifdef LIST_ASSERTS
 validate_list (LIST list)
+#else
+validate_list (HINT_PARAM_UNUSED LIST list)
+#endif
 {
 #ifdef LIST_ASSERTS
 	ASSERT(!list || (lhead(list)&&ltail(list)) || (!lhead(list)&&!ltail(list)));
-#else
-	list=list; /* unused */
 #endif
 }
 /*========================================

--- a/src/stdlib/llstrcmp.c
+++ b/src/stdlib/llstrcmp.c
@@ -142,7 +142,11 @@ set_usersort (usersortfnc fnc)
  * widecmp -- Perform unicode string comparison, if available
  *=================================================*/
 static BOOLEAN
+#ifdef HAVE_WCSCOLL
 widecmp (CNSTRING str1, CNSTRING str2, INT *rtn)
+#else
+widecmp (HINT_PARAM_UNUSED CNSTRING str1, HINT_PARAM_UNUSED CNSTRING str2, HINT_PARAM_UNUSED INT *rtn)
+#endif
 {
 	ZSTR zws1=0, zws2=0;
 	BOOLEAN success = FALSE;
@@ -158,13 +162,9 @@ widecmp (CNSTRING str1, CNSTRING str2, INT *rtn)
 		*rtn = wcscoll(wfs1, wfs2);
 		success = TRUE;
 	}
-#else
-	str1=str1; /* unused */
-	str2=str2; /* unused */
-	rtn=rtn; /* unused */
-#endif /* HAVE_WCSCOLL */
-
 	zs_free(&zws1);
 	zs_free(&zws2);
+#endif /* HAVE_WCSCOLL */
+
 	return success;
 }

--- a/src/stdlib/rbtree.c
+++ b/src/stdlib/rbtree.c
@@ -9,6 +9,8 @@
 
 #include "rbtree.h"
 
+#include "standard.h"
+
 /***********************************************************************
  * Data Structures: tree & node
  ***********************************************************************/
@@ -1017,9 +1019,8 @@ SafeMalloc (size_t size)
  ***********************************************************************/
 
 void
-NullFunction(void * junk)
+NullFunction(HINT_PARAM_UNUSED void * junk)
 {
-	junk=junk; /* unused */
 }
 int
 RbGetCount (RBTREE rbtree)

--- a/src/stdlib/vtable.c
+++ b/src/stdlib/vtable.c
@@ -52,18 +52,16 @@ generic_get_type_name (OBJECT obj)
  * nonrefcountable_isref -- simple isref for non-refcountable object
  *===============================================*/
 int
-nonrefcountable_isref (OBJECT obj)
+nonrefcountable_isref (HINT_PARAM_UNUSED OBJECT obj)
 {
-	obj = obj; /* NOTUSED */
 	return 0;
 }
 /*=================================================
  * refcountable_isref -- simple isref for generic refcountable object
  *===============================================*/
 int
-refcountable_isref (OBJECT obj)
+refcountable_isref (HINT_PARAM_UNUSED OBJECT obj)
 {
-	obj = obj; /* NOTUSED */
 	return 1;
 }
 /*=================================================

--- a/src/stdlib/zstr.c
+++ b/src/stdlib/zstr.c
@@ -426,11 +426,10 @@ zstr_destructor (VTABLE *obj)
  * zstr_copy -- copy for zstr
  *===============================================*/
 static OBJECT
-zstr_copy (OBJECT obj, int deep)
+zstr_copy (OBJECT obj, HINT_PARAM_UNUSED int deep)
 {
 	ZSTR zstr = (ZSTR)obj, znew=0;
 	ASSERT((*obj)->vtable_class == vtable_for_zstr.vtable_class);
-	deep=deep; /* unused */
 	ASSERT((*obj)->vtable_class == vtable_for_zstr.vtable_class);
 	znew = zs_newz(zstr);
 	return (OBJECT)znew;

--- a/src/tools/dbverify.c
+++ b/src/tools/dbverify.c
@@ -384,7 +384,6 @@ cgn_callback (TRAV_NAMES_FUNC_ARGS(key, name, newset, param))
 	/* a name record which points at indi=key */
 	RECORD indi0 = NULL;
 	NODE indi = NULL;
-	param=param; /* unused */
 
 	/* bail out immediately if not INDI */
 	if (key[0] != 'I') {
@@ -443,7 +442,6 @@ cgr_callback (TRAV_REFNS_FUNC_ARGS(key, refn, newset, param))
 	/* a refn record which points at record=key */
 	RECORD rec = key_to_record(key);
 	NODE node = nztop(rec);
-	param = param; /* unused */
 
 	if (newset) {
 		finish_and_delete_refnset();
@@ -602,7 +600,6 @@ fix_nodes (void)
 static BOOLEAN
 nodes_callback(TRAV_RECORDS_FUNC_ARGS(key, rec, param))
 {
-	param=param;	/* NOTUSED */
 	if (noisy)
 		report_progress("Checking Node: %s", key);
 	switch (key[0]) {
@@ -1044,11 +1041,8 @@ check_node (CNSTRING n0key, NODE node, INT level)
  * fix_bad_pointer -- Fix bad pointer if requested
  *=================================*/
 static BOOLEAN
-fix_bad_pointer (CNSTRING key, RECORD rec, NODE node)
+fix_bad_pointer (HINT_PARAM_UNUSED CNSTRING key, HINT_PARAM_UNUSED RECORD rec, NODE node)
 {
-	key=key; /* unused */
-	rec=rec; /* unused */
-
 	if (todo.fix_alter_pointers) {
 		change_node_tag(node, "_badptr");
 		return TRUE;

--- a/src/tools/lldump.c
+++ b/src/tools/lldump.c
@@ -277,7 +277,7 @@ check_rkey(keytype *kt, RKEY *key, BOOLEAN in_data) {
 		return;
 	}
 	memcpy(kt->rkey,key,9);  // grab string and 1 more char.
-	kt->rkey[8] = 0;         // RKEY is 1st 8 char of key,force 9th char to null
+	kt->rkey[8] = 0;         // RKEY is 1st 8 char of key, force 9th char to null
 	char *p = kt->rkey;
 	while (*p == ' ') p++;   // p points to 1st non-space char
 	kt->rkeyfirst = p;
@@ -302,7 +302,7 @@ check_rkey(keytype *kt, RKEY *key, BOOLEAN in_data) {
 	case 'X': strncpy(kt->rname,"Other",6); break;
 	case 'H': strncpy(kt->rname,"HIST",6);  break;
 	default:
-		printf("Error, unrecognized RKEY %s\n",p);
+		printf("Error, unrecognized RKEY '%s'\n",p);
 		strncpy(kt->rname,"Bad",6); 
 	}
 	//validity checks

--- a/src/tools/lldump.c
+++ b/src/tools/lldump.c
@@ -386,12 +386,9 @@ void dump_index(STRING dir)
 /*===============================
  * tf_print_index -- traversal function wrapper for print_index
  *=============================*/
-BOOLEAN tf_print_index(BTREE btree, INDEX index, void *param)
+BOOLEAN tf_print_index(HINT_PARAM_UNUSED BTREE btree, INDEX index, HINT_PARAM_UNUSED void *param)
 {
 	INT32 offset = 0;
-
-	btree = btree;	/* UNUSED */
-	param = param;	/* UNUSED */
 
 	print_index(index, &offset);
 	return TRUE;
@@ -528,12 +525,9 @@ void dump_block(STRING dir)
 /*===============================
  * tf_print_block -- traversal function wrapper for print_block
  *=============================*/
-BOOLEAN tf_print_block(BTREE btree, BLOCK block, void *param)
+BOOLEAN tf_print_block(HINT_PARAM_UNUSED BTREE btree, BLOCK block, HINT_PARAM_UNUSED void *param)
 {
 	INT32 offset = 0;
-
-	btree = btree;	/* UNUSED */
-	param = param;	/* UNUSED */
 
 	print_block(btree, block, &offset);
 	return TRUE;

--- a/src/tools/wprintf.c
+++ b/src/tools/wprintf.c
@@ -86,8 +86,7 @@ msg_status (char *fmt, ...)
  * this would not be needed here. - Perry, 2001/11/11
  *====================================*/
 void
-poutput (char *str, BOOLEAN *eflg)
+poutput (char *str, HINT_PARAM_UNUSED BOOLEAN *eflg)
 {
-	eflg=eflg; /* unused */
 	printf("%s", str);
 }

--- a/src/ui/ui_cli.c
+++ b/src/ui/ui_cli.c
@@ -111,10 +111,9 @@ msg_status (char *fmt, ...)
 	va_end(args);
 }
 void
-msg_output (MSG_LEVEL level, STRING fmt, ...)
+msg_output (HINT_PARAM_UNUSED MSG_LEVEL level, STRING fmt, ...)
 {
 	va_list args;
-	level=level;
 	va_start(args, fmt);
 	vprintf(fmt, args);
 	va_end(args);
@@ -148,22 +147,14 @@ call_system_cmd (STRING cmd)
  * ASK Routines
  *===========================================================*/
 BOOLEAN
-ask_for_program (STRING mode,
-                 STRING ttl,
-                 STRING *pfname,
-                 STRING *pfullpath,
-                 STRING path,
-                 STRING ext,
-                 BOOLEAN picklist)
+ask_for_program (HINT_PARAM_UNUSED STRING mode,
+                 HINT_PARAM_UNUSED STRING ttl,
+                 HINT_PARAM_UNUSED STRING *pfname,
+                 HINT_PARAM_UNUSED STRING *pfullpath,
+                 HINT_PARAM_UNUSED STRING path,
+                 HINT_PARAM_UNUSED STRING ext,
+                 HINT_PARAM_UNUSED BOOLEAN picklist)
 {
-	mode = mode;		/* NOTUSED */
-	ttl = ttl;		/* NOTUSED */
-	pfname = pfname;	/* NOTUSED */
-	pfullpath = pfullpath;	/* NOTUSED */
-	path = path;		/* NOTUSED */
-	ext = ext;		/* NOTUSED */
-	picklist = picklist;	/* NOTUSED */
-
 	/* TODO: We probably want to use the real implementation in askprogram.c */
 	return FALSE;
 }
@@ -218,9 +209,8 @@ ask_yes_or_no_msg (STRING msg, STRING ttl)
 	return yes_no_value(c);
 }
 BOOLEAN
-ask_for_db_filename (CNSTRING ttl, CNSTRING prmpt, CNSTRING basedir, STRING buffer, INT buflen)
+ask_for_db_filename (CNSTRING ttl, CNSTRING prmpt, HINT_PARAM_UNUSED CNSTRING basedir, STRING buffer, INT buflen)
 {
-	basedir = basedir;	/* NOTUSED */
 	return ask_for_string(ttl, prmpt, buffer, buflen);
 }
 BOOLEAN
@@ -297,11 +287,8 @@ choose_list_from_indiseq (STRING ttl, INDISEQ seq)
 	return choose_one_or_list_from_indiseq(ttl, seq, TRUE);
 }
 INT
-choose_one_or_list_from_indiseq (STRING ttl, INDISEQ seq, BOOLEAN multi)
+choose_one_or_list_from_indiseq (HINT_PARAM_UNUSED STRING ttl, INDISEQ seq, HINT_PARAM_UNUSED BOOLEAN multi)
 {
-	ttl = ttl;	/* NOTUSED */
-	multi = multi;	/* NOTUSED */
-
 	calc_indiseq_names(seq); /* we certainly need the names */
 
 	/* TODO: imitate choose_from_list & delegate to array chooser */


### PR DESCRIPTION
Built with gcc-9, gcc-10 and clang-12.

* Added `-Wextra` to the default flags for gcc-compatible compilers
* Fix boolean logic error in `src/btree/opnbtree.c`
* Deal with `-Wcast-align` warnings in `src/tools/lldump.c` with local macros plus new macros in `src/hdrs/btree.h`
* Deal with unused parameter warnings throughout
