### PR TITLE
Avoid double free

### DIFF
--- a/src/gedlib/names.c
+++ b/src/gedlib/names.c
@@ -147,8 +147,11 @@ static void
 freenamerec(void)
 {
 	stdfree(NRkeys);
+	NRkeys = NULL;
 	stdfree(NRoffs);
+	NRoffs = NULL;
 	stdfree((STRING)NRnames);
+	NRnames = NULL;
 	NRmax = 0;
 }
 

--- a/src/gedlib/refns.c
+++ b/src/gedlib/refns.c
@@ -137,8 +137,11 @@ static void
 freerefnrec(void)
 {
         stdfree(RRkeys);
+	RRkeys = NULL;
         stdfree(RRoffs);
+	RRoffs = NULL;
         stdfree((CNSTRING)RRrefns);
+	RRrefns = NULL;
         RRmax = 0;
 }
 
@@ -176,8 +179,12 @@ freerefnmrec(void)
 	INT i;
 
 	for (i = 0; i < RMcount; i++)
+	{
 		stdfree(RMkeys[i]);
+		RMkeys[i] = NULL;
+	}
 	stdfree(RMkeys);
+	RMkeys = NULL;
 	RMcount = 0;
 	RMmax = 0;
 }
@@ -239,7 +246,10 @@ getrefnrec (CNSTRING refn)
 	STRING p;
 /* Convert refn to key and read refn record */
 	RRkey = refn2rkey(refn);
-	if (RRrec) stdfree(RRrec);
+	if (RRrec) {
+		stdfree(RRrec);
+		RRrec = NULL;
+	}
 	p = RRrec = bt_getrecord(BTR, &RRkey, &RRsize);
 	if (!RRrec) {
 		RRcount = 0;


### PR DESCRIPTION
When freeing global pointers in NAME or REFN code, be sure to NULL out the pointers so that we don't trigger a double free.
This can happen during `reallocnamerec()`, `reallocrefnrec()` or `reallocrefnmrec()`.

Fixes #85 