### PR TITLE
Adding more than 32 ASSOs to an INDI causes corruption

### DIFF
--- a/src/gedlib/keytonod.c
+++ b/src/gedlib/keytonod.c
@@ -668,9 +668,11 @@ add_to_direct (CACHE cache, CNSTRING key, INT reportmode)
 	ASSERT(key);
 
 	/* retrieve raw record and create record from it */
-	if ((rawrec = retrieve_raw_record(key, &len)))
+	if ((rawrec = retrieve_raw_record(key, &len))) {
+		ASSERT(rawrec);
 		/* 2003-11-22, we should use string_to_node here */
 		rec = string_to_record(rawrec, key, len);
+	}
 
 	/* handle failure to create record */
 	if (!rec)

--- a/src/gedlib/llgettext.c
+++ b/src/gedlib/llgettext.c
@@ -177,7 +177,7 @@ void
 #if ENABLE_NLS
 set_gettext_codeset (CNSTRING domain, CNSTRING codeset)
 #else
-set_gettext_codeset (HINT_UNUSED_PARAM CNSTRING domain, HINT_UNUSED_PARAM CNSTRING codeset)
+set_gettext_codeset (HINT_PARAM_UNUSED CNSTRING domain, HINT_PARAM_UNUSED CNSTRING codeset)
 #endif
 {
 #if ENABLE_NLS

--- a/src/gedlib/misc.c
+++ b/src/gedlib/misc.c
@@ -79,20 +79,23 @@ rmvat_char (CNSTRING str, char c, char d)
 	/*
 	 * This static buffer is an array of buffers that can be used for
 	 * addat'ed strings.  We need to use an array here since we may have
-	 * multiple calls within a single operation and we don't want to overwrite
-	 * values that haven't been copied or otherwise made permanent.
+	 * multiple calls within a single operation and we don't want to
+	 * overwrite values that haven't been copied or made permanent.
 	 * Since GEDCOM 5.5 spefies that XREF values can be up to 22 chars,
 	 * the static buffer needs to be at least 22+2+1=25 chars, but leave a
 	 * little extra.
 	 *
 	 * Currently we need to support a large number of rmvat() calls.
 	 *
-	 * The previous limit of 32 (and before that, 10) were insufficient when
-	 * parsing INDI records that have a lot of keys in them.  For example,
-	 * https://github.com/lifelines/lifelines/issues/439 reported errors
-	 * editing (or importing) INDI records with more than 32 ASSO values;
-	 * the 33rd would wrap and use the first entry again, thus "corrupting"
-	 * the value there, resulting in bad data being stored to the database.
+	 * The current limit of 32 appears sufficient, but there may be cases
+	 * where static buffer reuse causes data corruption of various types.
+	 * The solutions are to a) ensure that the values returned by rmvat()
+	 * are saved, or b) increase the buffer size.
+	 *
+	 * Refer to https://github.com/lifelines/lifelines/issues/439 for one
+	 * such scenario; a single INDI with 32 ASSO tags caused the INDI key
+	 * to become corrupted because the ASSO tag processing caused the rmvat
+	 * buffer to wrap.
 	 */
 #define RMVAT_SIZE 32
 	static char buffer[RMVAT_SIZE][32];

--- a/src/gedlib/misc.c
+++ b/src/gedlib/misc.c
@@ -36,6 +36,9 @@
 #include "gedcom.h"
 #include "zstr.h"
 
+static INT addat_count = 0;
+static INT rmvat_count = 0;
+
 /*========================================
  * addat -- Add @'s to both ends of string
  *  returns static buffer
@@ -58,6 +61,7 @@ addat (STRING str)
 	static char buffer[ADDAT_SIZE][32];
 	static INT dex = 0;
 	STRING p;
+	addat_count++;
 	dex++;
 	if (dex == ADDAT_SIZE) dex = 0;
 	p = buffer[dex];
@@ -99,6 +103,7 @@ rmvat_char (CNSTRING str, char c, char d)
 	/* Watch out for bad pointers */
 	if((str == NULL) || (*str == '\0')) return(NULL);
 	if (str[0] != c) return NULL;
+	rmvat_count++;
 	dex++;
 	if (dex == RMVAT_SIZE) dex = 0;
 	p = buffer[dex];
@@ -129,12 +134,20 @@ rmvbrackets (CNSTRING str)
 	return rmvat_char(str, '<', '>');
 }
 /*=============================================
- * get_rmvat_size -- max number of rmvat calls
+ * get_rmvat_size -- size of rmvat static array
  *===========================================*/
 INT
 get_rmvat_size (void)
 {
 	return RMVAT_SIZE;
+}
+/*=============================================
+ * get_rmvat_count -- count of rmvat calls
+ *===========================================*/
+INT
+get_rmvat_count (void)
+{
+	return rmvat_count;
 }
 /*=============================================
  * node_to_keynum -- key # of a 0 level node

--- a/src/gedlib/misc.c
+++ b/src/gedlib/misc.c
@@ -49,13 +49,13 @@ addat (STRING str)
 	/*
 	 * This static buffer is an array of buffers that can be used for
 	 * addat'ed strings.  We need to use an array here since we may have
-	 * nested calls within a single operation and we don't want to overwrite
+	 * multiple calls within a single operation and we don't want to overwrite
 	 * values that haven't been copied or otherwise made permanent.
 	 * Since GEDCOM 5.5 spefies that XREF values can be up to 22 chars,
 	 * the static buffer needs to be at least 22+2+1=25 chars, but leave a
 	 * little extra.
 	 *
-	 * Currently we need to support up to 3 nested addat() calls.
+	 * Currently we need to support up to 3 addat() calls.
 	 */
 #define ADDAT_SIZE 3
 	static char buffer[ADDAT_SIZE][32];
@@ -79,13 +79,13 @@ rmvat_char (CNSTRING str, char c, char d)
 	/*
 	 * This static buffer is an array of buffers that can be used for
 	 * addat'ed strings.  We need to use an array here since we may have
-	 * nested calls within a single operation and we don't want to overwrite
+	 * multiple calls within a single operation and we don't want to overwrite
 	 * values that haven't been copied or otherwise made permanent.
 	 * Since GEDCOM 5.5 spefies that XREF values can be up to 22 chars,
 	 * the static buffer needs to be at least 22+2+1=25 chars, but leave a
 	 * little extra.
 	 *
-	 * Currently we need to support a large number of nested rmvat() calls.
+	 * Currently we need to support a large number of rmvat() calls.
 	 *
 	 * The previous limit of 32 (and before that, 10) were insufficient when
 	 * parsing INDI records that have a lot of keys in them.  For example,
@@ -132,22 +132,6 @@ STRING
 rmvbrackets (CNSTRING str)
 {
 	return rmvat_char(str, '<', '>');
-}
-/*=============================================
- * get_rmvat_size -- size of rmvat static array
- *===========================================*/
-INT
-get_rmvat_size (void)
-{
-	return RMVAT_SIZE;
-}
-/*=============================================
- * get_rmvat_count -- count of rmvat calls
- *===========================================*/
-INT
-get_rmvat_count (void)
-{
-	return rmvat_count;
 }
 /*=============================================
  * node_to_keynum -- key # of a 0 level node

--- a/src/gedlib/nodeio.c
+++ b/src/gedlib/nodeio.c
@@ -452,6 +452,7 @@ string_to_record (STRING str, CNSTRING key, HINT_PARAM_UNUSED INT len)
 	}
 	if (node) {
 		rec = create_record_for_keyed_node(node, key);
+		ASSERT(rec);
 	}
 	return rec;
 }

--- a/src/gedlib/record.c
+++ b/src/gedlib/record.c
@@ -290,6 +290,7 @@ RECORD
 create_record_for_keyed_node (NODE node, CNSTRING key)
 {
 	RECORD rec = alloc_new_record();
+	ASSERT(rec);
 	if (!key)
 		key = nxref(node);
 	rec->rec_top = node;

--- a/src/hdrs/gedcom.h
+++ b/src/hdrs/gedcom.h
@@ -292,6 +292,7 @@ STRING get_original_locale_msgs(void);
 STRING get_property(STRING opt);
 void get_refns(STRING, INT*, STRING**, INT);
 INT get_rmvat_size(void);
+INT get_rmvat_count(void);
 STRING getexref(void);
 STRING getfxref(void);
 INT32 getixrefnum(void);

--- a/src/hdrs/gedcom.h
+++ b/src/hdrs/gedcom.h
@@ -291,6 +291,7 @@ STRING get_original_locale_collate(void);
 STRING get_original_locale_msgs(void);
 STRING get_property(STRING opt);
 void get_refns(STRING, INT*, STRING**, INT);
+INT get_rmvat_size(void);
 STRING getexref(void);
 STRING getfxref(void);
 INT32 getixrefnum(void);

--- a/src/hdrs/gedcom.h
+++ b/src/hdrs/gedcom.h
@@ -291,8 +291,6 @@ STRING get_original_locale_collate(void);
 STRING get_original_locale_msgs(void);
 STRING get_property(STRING opt);
 void get_refns(STRING, INT*, STRING**, INT);
-INT get_rmvat_size(void);
-INT get_rmvat_count(void);
 STRING getexref(void);
 STRING getfxref(void);
 INT32 getixrefnum(void);

--- a/src/liflines/add.c
+++ b/src/liflines/add.c
@@ -200,10 +200,12 @@ add_indi_no_cache (NODE indi)
 	NODE node, name, refn, sex, body, famc, fams;
 	STRING str, key;
 
-	split_indi_old(indi, &name, &refn, &sex, &body, &famc, &fams);
-	// get stable value for key in case rmvat static array gets corrupted
-	// this prevents us writing the record using the wrong key.
+	// Save INDI key value since rmvat static array entries may get reused
+	// before we write the INDI out (for example, >32 ASSO tags). This
+	// prevents us from writing the record out using the wrong key.
 	key = strsave(rmvat(nxref(indi)));
+
+	split_indi_old(indi, &name, &refn, &sex, &body, &famc, &fams);
 	for (node = name; node; node = nsibling(node))
 		add_name(nval(node), key);
 	for (node = refn; node; node = nsibling(node))

--- a/src/liflines/add.c
+++ b/src/liflines/add.c
@@ -201,7 +201,7 @@ add_indi_no_cache (NODE indi)
 	STRING str, key;
 
 	split_indi_old(indi, &name, &refn, &sex, &body, &famc, &fams);
-	key = rmvat(nxref(indi));
+	key = strsave(rmvat(nxref(indi)));
 	for (node = name; node; node = nsibling(node))
 		add_name(nval(node), key);
 	for (node = refn; node; node = nsibling(node))
@@ -211,6 +211,7 @@ add_indi_no_cache (NODE indi)
 	str = node_to_string(indi);
 	store_record(key, str, strlen(str));
 	stdfree(str);
+	stdfree(key);
 	return TRUE;
 }
 /*========================================================

--- a/src/liflines/add.c
+++ b/src/liflines/add.c
@@ -201,6 +201,8 @@ add_indi_no_cache (NODE indi)
 	STRING str, key;
 
 	split_indi_old(indi, &name, &refn, &sex, &body, &famc, &fams);
+	// get stable value for key in case rmvat static array gets corrupted
+	// this prevents us writing the record using the wrong key.
 	key = strsave(rmvat(nxref(indi)));
 	for (node = name; node; node = nsibling(node))
 		add_name(nval(node), key);

--- a/src/liflines/valgdcom.c
+++ b/src/liflines/valgdcom.c
@@ -1034,11 +1034,13 @@ clear_structures (void)
 	}
 	for (i = 0; i < struct_len; i++) {
 		ELMNT el = index_data[i];
-		index_data[i] = 0;
+		index_data[i] = NULL;
 		free_elmnt(el);
 	}
 	stdfree(index_data);
+	index_data = NULL;
 	struct_len = 0;
+	struct_max = 0;
 }
 /*=====================================
  * set_import_log -- Specify where import errors logged


### PR DESCRIPTION
Fixes #439

During GEDCOM import, ensure that the key for INDIs is copied, since if there are many records that need keys resolved (eg, ASSOs), the static array used for output in rmvat() will wrap.  This will cause the INDI to get written to the wrong place.

Main change in liflines/add.c.
Cleanup and static vars for debugging in gedlib/misc.c
Code cleanup throughout.