### PR TITLE
Fix memory accounting in scandir() polyfill

### DIFF
--- a/src/arch/scandir.c
+++ b/src/arch/scandir.c
@@ -136,7 +136,6 @@ scandir(const char *dir, struct dirent ***namelist,
   struct dirent *current;
   struct dirent **names = NULL;
   int pos = 0;
-  int result = -1;
 
   if (NULL == d)
     return -1;
@@ -158,7 +157,7 @@ scandir(const char *dir, struct dirent ***namelist,
       pos++;
     }
   }
-  result = closedir(d);
+  closedir(d);
 
   *namelist = names;
 

--- a/src/arch/scandir.c
+++ b/src/arch/scandir.c
@@ -134,26 +134,23 @@ scandir(const char *dir, struct dirent ***namelist,
 {
   DIR *d = opendir(dir);
   struct dirent *current;
-  struct dirent **names;
-  int count = 0;
+  struct dirent **names = NULL;
   int pos = 0;
   int result = -1;
 
   if (NULL == d)
     return -1;
 
-  while (NULL != readdir(d)) count++;
-
-  names = malloc(sizeof(struct dirent *) * count);
-
-  closedir(d);
-  d = opendir(dir);
-  if (NULL == d)
-    return -1;
-
   while (NULL != (current = readdir(d))) {
     if ( NULL == select || select(current) ) {
+      struct dirent **newnames = realloc(names, sizeof(*names) * (pos + 1))
+      if (NULL == newnames)
+        continue;
+      names = newnames;
+
       struct dirent *copyentry = malloc(current->d_reclen);
+      if (NULL == copyentry)
+        continue;
 
       memcpy(copyentry, current, current->d_reclen);
 
@@ -162,9 +159,6 @@ scandir(const char *dir, struct dirent ***namelist,
     }
   }
   result = closedir(d);
-
-  if (pos != count)
-    names = realloc(names, sizeof(struct dirent *)*pos);
 
   *namelist = names;
 


### PR DESCRIPTION
Adapted-from: https://github.com/gpg/boa/pull/1/commits/e139b87835994d007fbd64eead6c1455d7b8cf4e
Closes: https://bugs.debian.org/1084524